### PR TITLE
Unify naming: yak-robotics → yakrover across all files

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -317,7 +317,7 @@ AUCTION_DB_PATH=./auction.db PYTHONPATH=. uv run python serve_with_auction.py
 **Connect Claude Code:**
 
 ```bash
-claude mcp add-json yak-robotics '{"type":"http","url":"http://localhost:8001/fleet/mcp"}'
+claude mcp add-json yakrover '{"type":"http","url":"http://localhost:8001/fleet/mcp"}'
 ```
 
 **Then talk naturally:**
@@ -351,7 +351,7 @@ The demo uses mock robots and Stripe test mode. Here is what changes for product
 | **Stripe keys** | `sk_test_xxx` — test mode, no real money | `sk_live_xxx` — real charges and payouts ($1K-$72K+ construction tasks) |
 | **Payment method** | Manual `.env` setup | Payment bonds (public projects), escrow (private), or prepaid credits |
 | **Operator payouts** | Stub or test transfers | Stripe Connect Express — operators complete hosted KYB onboarding (~2 min) |
-| **Agent connection** | `claude mcp add-json yak-robotics '{"type":"http","url":"http://localhost:8001/fleet/mcp"}'` | Same command with public URL |
+| **Agent connection** | `claude mcp add-json yakrover '{"type":"http","url":"http://localhost:8001/fleet/mcp"}'` | Same command with public URL |
 
 **Production checklist:**
 1. Register robots on ERC-8004 Sepolia (or mainnet) — each robot gets an on-chain identity

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ uv run pytest auction/tests/ -q --tb=short
 PYTHONPATH=. uv run python auction/demo.py
 
 # Or connect as MCP server
-claude mcp add-json yak-robotics '{"type":"http","url":"http://localhost:8001/fleet/mcp"}'
+claude mcp add-json yakrover '{"type":"http","url":"http://localhost:8001/fleet/mcp"}'
 ```
 
 See [GETTING_STARTED.md](GETTING_STARTED.md) for full setup including Stripe and robot simulator.

--- a/chatbot/src/index.js
+++ b/chatbot/src/index.js
@@ -1087,7 +1087,7 @@ async function handleUploadDelivery(request, env, cors) {
 
   // Package the delivery with metadata
   const deliveryPackage = {
-    schema: "yak-robotics/delivery/v1",
+    schema: "yakrover/delivery/v1",
     request_id,
     robot_id: robot_id || "unknown",
     robot_name: robot_name || "Unknown Robot",

--- a/demo/_archive/index-v5.html
+++ b/demo/_archive/index-v5.html
@@ -1386,7 +1386,7 @@ function renderAgentStep(){
 
     if(s.agent==='claude-code'){
       // Claude Code: one-liner command
-      var addCmd='claude mcp add-json yak-robotics \'{"type":"http","url":"'+mcpUrl+'","headers":{"Authorization":"Bearer '+s.apiKey+'"}}\'';
+      var addCmd='claude mcp add-json yakrover \'{"type":"http","url":"'+mcpUrl+'","headers":{"Authorization":"Bearer '+s.apiKey+'"}}\'';
       html+='<h3>Step 3: Run this in your terminal</h3>';
       html+='<p>One command — Claude Code handles the rest. No config files to edit.</p>';
       html+='<div class="config-snippet" id="agentConfigSnippet">'+addCmd+'</div>';
@@ -1418,7 +1418,7 @@ function renderAgentStep(){
 
     } else {
       // Custom: show full JSON config
-      var configJson='{\n  "mcpServers": {\n    "yak-robotics": {\n      "type": "http",\n      "url": "'+mcpUrl+'",\n      "headers": {\n        "Authorization": "Bearer '+s.apiKey+'"\n      }\n    }\n  }\n}';
+      var configJson='{\n  "mcpServers": {\n    "yakrover": {\n      "type": "http",\n      "url": "'+mcpUrl+'",\n      "headers": {\n        "Authorization": "Bearer '+s.apiKey+'"\n      }\n    }\n  }\n}';
       html+='<h3>Step 3: MCP Configuration</h3>';
       html+='<p>Add this to your agent\'s MCP server configuration:</p>';
       html+='<div class="config-snippet" id="agentConfigSnippet">'+configJson+'</div>';

--- a/demo/index.html
+++ b/demo/index.html
@@ -2540,7 +2540,7 @@ function renderAgentStep(){
 
     if(s.agent==='claude-code'){
       // Claude Code: one-liner command
-      var addCmd='claude mcp add-json yak-robotics \'{"type":"http","url":"'+mcpUrl+'","headers":{"Authorization":"Bearer '+s.apiKey+'"}}\'';
+      var addCmd='claude mcp add-json yakrover \'{"type":"http","url":"'+mcpUrl+'","headers":{"Authorization":"Bearer '+s.apiKey+'"}}\'';
       html+='<h3>Step 3: Run this in your terminal</h3>';
       html+='<p>One command — Claude Code handles the rest. No config files to edit.</p>';
       html+='<div class="config-snippet" id="agentConfigSnippet">'+addCmd+'</div>';
@@ -2572,7 +2572,7 @@ function renderAgentStep(){
 
     } else {
       // Custom: show full JSON config
-      var configJson='{\n  "mcpServers": {\n    "yak-robotics": {\n      "type": "http",\n      "url": "'+mcpUrl+'",\n      "headers": {\n        "Authorization": "Bearer '+s.apiKey+'"\n      }\n    }\n  }\n}';
+      var configJson='{\n  "mcpServers": {\n    "yakrover": {\n      "type": "http",\n      "url": "'+mcpUrl+'",\n      "headers": {\n        "Authorization": "Bearer '+s.apiKey+'"\n      }\n    }\n  }\n}';
       html+='<h3>Step 3: MCP Configuration</h3>';
       html+='<p>Add this to your agent\'s MCP server configuration:</p>';
       html+='<div class="config-snippet" id="agentConfigSnippet">'+configJson+'</div>';

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,7 +14,7 @@ PYTHONPATH=. uv run python mcp_server.py
 Server runs at `http://localhost:8001`. Connect your own Claude:
 
 ```bash
-claude mcp add --transport http yak-robotics http://localhost:8001/mcp
+claude mcp add --transport http yakrover http://localhost:8001/mcp
 ```
 
 ### Public access (free Cloudflare Tunnel)
@@ -47,7 +47,7 @@ cloudflared tunnel run --url http://localhost:8001 yak-demo
 ### Claude Code (terminal)
 
 ```bash
-claude mcp add --transport http yak-robotics https://YOUR-URL-HERE/mcp
+claude mcp add --transport http yakrover https://YOUR-URL-HERE/mcp
 ```
 
 ### Claude Desktop (GUI)
@@ -57,7 +57,7 @@ Add to your MCP config file:
 ```json
 {
   "mcpServers": {
-    "yak-robotics": {
+    "yakrover": {
       "type": "http",
       "url": "https://YOUR-URL-HERE/mcp"
     }

--- a/docs/_archive/FRONTEND_DESIGN_SPRINT.md
+++ b/docs/_archive/FRONTEND_DESIGN_SPRINT.md
@@ -102,7 +102,7 @@ An AI agent (Claude, GPT, or any MCP-capable agent) discovers and uses the marke
 The agent fetches `https://marketplace.yakrobotics.com/.well-known/mcp.json` and finds:
 ```json
 {
-  "name": "yak-robotics-marketplace",
+  "name": "yakrover-marketplace",
   "description": "Robot task auction marketplace — post tasks, robots bid, best one wins",
   "version": "1.5.0",
   "tools": [
@@ -261,7 +261,7 @@ After each successful delivery, payment transfers to the operator's connected ac
 ```json
 {
   "mcpServers": {
-    "yak-robotics-marketplace": {
+    "yakrover-marketplace": {
       "url": "https://marketplace.yakrobotics.com/mcp/sse",
       "auth": {
         "type": "oauth2",

--- a/docs/onboarding/ROBOT_OPERATOR_ONBOARDING.md
+++ b/docs/onboarding/ROBOT_OPERATOR_ONBOARDING.md
@@ -306,7 +306,7 @@ The marketplace wraps this in a delivery envelope and uploads to IPFS:
 
 ```json
 {
-  "schema": "yak-robotics/delivery/v1",
+  "schema": "yakrover/delivery/v1",
   "request_id": "demo_1234567",
   "robot_id": "989",
   "delivered_at": "2026-04-02T10:30:00Z",

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -18,10 +18,10 @@ Usage:
     AUCTION_DB_PATH=./auction.db PYTHONPATH=. uv run python mcp_server.py
 
 Then connect Claude Code:
-    claude mcp add --transport http yak-robotics http://localhost:8001/mcp
+    claude mcp add --transport http yakrover http://localhost:8001/mcp
 
 Or Claude Desktop (add to config):
-    {"mcpServers": {"yak-robotics": {"type": "http", "url": "http://localhost:8001/mcp"}}}
+    {"mcpServers": {"yakrover": {"type": "http", "url": "http://localhost:8001/mcp"}}}
 
 Then ask:
     "I need a topographic survey for a 3-mile highway corridor in Michigan"
@@ -127,7 +127,7 @@ def create_app():
     engine, wallet, stripe_service = build_engine()
 
     mcp = FastMCP(
-        "yak-robotics",
+        "yakrover",
         instructions="""You are connected to the YAK ROBOTICS construction survey marketplace.
 
 You have 32 tools for managing the full survey lifecycle:
@@ -284,10 +284,10 @@ def main():
     print(f"    Tools:  {base_url}/api/tools")
     print()
     print("  Connect Claude Code:")
-    print(f"    claude mcp add --transport http yak-robotics {base_url}/mcp")
+    print(f"    claude mcp add --transport http yakrover {base_url}/mcp")
     print()
     print("  Connect Claude Desktop (add to config):")
-    print(f'    {{"mcpServers": {{"yak-robotics": {{"type": "http", "url": "{base_url}/mcp"}}}}}}')
+    print(f'    {{"mcpServers": {{"yakrover": {{"type": "http", "url": "{base_url}/mcp"}}}}}}')
     print()
     print("  Then ask:")
     print('    "I need a topo survey for a highway project in Michigan"')


### PR DESCRIPTION
Aligns MCP server name, delivery schema, CLI examples, and config snippets to use consistent "yakrover" naming.