### PR TITLE
Add GROUND_DELIVERY_SCHEMA for delivery_ground tasks

### DIFF
--- a/auction/delivery_schemas.py
+++ b/auction/delivery_schemas.py
@@ -346,6 +346,35 @@ ENV_SENSING_SCHEMA = {
 }
 
 
+# ── Ground Delivery / Teleop (Tumbller and similar wheeled robots) ───
+# Deliverables: command log with timestamps, completion status
+
+GROUND_DELIVERY_SCHEMA = {
+    "description": "Ground robot delivery/teleop deliverable — executed command log and completion status",
+    "required": ["task_id", "commands_executed", "duration_s", "completion_status", "summary"],
+    "properties": {
+        "task_id": {"type": "string", "minLength": 1},
+        "commands_executed": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["command", "timestamp_ms", "duration_ms"],
+                "properties": {
+                    "command": {"type": "string"},  # "forward", "backward", "left", "right", "stop"
+                    "timestamp_ms": {"type": "integer", "minimum": 0},
+                    "duration_ms": {"type": "integer", "minimum": 0},
+                },
+            },
+        },
+        "duration_s": {"type": "number", "minimum": 0},
+        "completion_status": {"type": "string"},  # "completed", "partial", "aborted"
+        "robot_id": {"type": "string"},
+        "summary": {"type": "string", "minLength": 1},
+    },
+}
+
+
 # ── Category → Schema mapping ────────────────────────────────────
 
 DELIVERY_SCHEMAS = {
@@ -368,6 +397,7 @@ DELIVERY_SCHEMAS = {
     "environmental_survey": AERIAL_PHOTO_SCHEMA,
     "control_survey": AERIAL_LIDAR_SCHEMA,
     "mapping": AERIAL_LIDAR_SCHEMA,
+    "delivery_ground": GROUND_DELIVERY_SCHEMA,
 }
 
 

--- a/auction/mcp_tools.py
+++ b/auction/mcp_tools.py
@@ -118,6 +118,7 @@ COMMON_MODELS = {
     "gpr": "Boston Dynamics Spot + GSSI StructureScan Mini XT",
     "rtk_gps": "Trimble R12i",
     "robotic_total_station": "Leica TS16",
+    "ground_robot": "ELEGOO Tumbller (ESP32-S3)",
 }
 
 # Sensor type → default task category (used by register_robot_onchain)
@@ -129,6 +130,7 @@ SENSOR_TO_CATEGORY = {
     "rtk_gps": "env_sensing",
     "thermal_camera": "visual_inspection",
     "robotic_total_station": "env_sensing",
+    "ground_robot": "delivery_ground",
 }
 
 # Blockchain chain configs (used by register_robot_onchain and eas_attest)

--- a/auction/tests/test_delivery_schemas_e2e.py
+++ b/auction/tests/test_delivery_schemas_e2e.py
@@ -17,6 +17,7 @@ from auction.delivery_schemas import (
     CONFINED_SCHEMA,
     CORRIDOR_SCHEMA,
     ENV_SENSING_SCHEMA,
+    GROUND_DELIVERY_SCHEMA,
     GROUND_GPR_SCHEMA,
     GROUND_LIDAR_SCHEMA,
     get_delivery_schema,
@@ -239,6 +240,27 @@ def make_env_sensing_delivery():
     }
 
 
+def make_ground_delivery():
+    start_ts = int(time.time() * 1000)
+    commands = ["forward", "left", "forward", "right", "stop"]
+    command_log = [
+        {
+            "command": cmd,
+            "timestamp_ms": start_ts + i * 1000,
+            "duration_ms": random.randint(200, 1500),
+        }
+        for i, cmd in enumerate(commands)
+    ]
+    return {
+        "task_id": f"task_{random.randint(1000, 9999)}",
+        "commands_executed": command_log,
+        "duration_s": round(sum(c["duration_ms"] for c in command_log) / 1000.0, 2),
+        "completion_status": "completed",
+        "robot_id": "8453:42",
+        "summary": f"Executed {len(commands)} motor commands.",
+    }
+
+
 # Corridor reuses aerial LiDAR structure with additions
 def make_corridor_delivery():
     base = make_aerial_lidar_delivery()
@@ -352,13 +374,39 @@ class TestCorridor:
         assert get_delivery_schema("corridor_survey") == CORRIDOR_SCHEMA
 
 
+class TestGroundDelivery:
+    def test_schema_passes(self):
+        data = make_ground_delivery()
+        issues = validate_delivery_schema(data, GROUND_DELIVERY_SCHEMA)
+        assert issues == [], f"Ground delivery schema failed: {issues}"
+
+    def test_category_mapping(self):
+        assert get_delivery_schema("delivery_ground") == GROUND_DELIVERY_SCHEMA
+
+    def test_missing_required_field_fails(self):
+        data = make_ground_delivery()
+        del data["commands_executed"]
+        issues = validate_delivery_schema(data, GROUND_DELIVERY_SCHEMA)
+        assert any("commands_executed" in i for i in issues), (
+            f"Expected missing-field issue for commands_executed, got: {issues}"
+        )
+
+    def test_empty_command_log_fails(self):
+        data = make_ground_delivery()
+        data["commands_executed"] = []
+        issues = validate_delivery_schema(data, GROUND_DELIVERY_SCHEMA)
+        assert any("minimum 1" in i for i in issues), (
+            f"Expected minItems violation for empty commands_executed, got: {issues}"
+        )
+
+
 class TestAllCategoriesCovered:
     """Verify every task category in the mapping has a test."""
 
-    def test_all_17_categories_mapped(self):
+    def test_all_categories_mapped(self):
         from auction.delivery_schemas import DELIVERY_SCHEMAS
 
-        assert len(DELIVERY_SCHEMAS) == 18
+        assert len(DELIVERY_SCHEMAS) == 19
         for cat in DELIVERY_SCHEMAS:
             schema = get_delivery_schema(cat)
             assert schema is not None, f"No schema for {cat}"


### PR DESCRIPTION
## Summary
- New `GROUND_DELIVERY_SCHEMA` in `auction/delivery_schemas.py` for ground / teleop robots
- Mapping `delivery_ground → GROUND_DELIVERY_SCHEMA` added to `DELIVERY_SCHEMAS`
- 4 new tests: valid payload, category lookup, missing-required-field failure, empty-command-log failure

## Why
`delivery_ground` was already listed in `DEFAULT_QA_LEVELS` (level 1) but had no entry in `DELIVERY_SCHEMAS`, so deliveries for this category fell back to `ENV_SENSING_SCHEMA` and failed QA. This matches the note in `CLAUDE.md`: *"delivery schema per task type (QA currently fails for non-temperature tasks)"*.

The schema captures what a ground / teleop robot actually produces:
- `task_id`
- `commands_executed`: list of `{command, timestamp_ms, duration_ms}` (minItems: 1)
- `duration_s`
- `completion_status`
- `robot_id`
- `summary`

## Context
First concrete contribution from a larger plan to register a new live-production ground robot (`berlin-tumbller-01` / `NPC ROBOT`) under the `delivery_ground` category. The plan (in `tumbller-esp32s3/docs/MARKETPLACE_REGISTRATION_PLAN.md`, not part of this PR) deliberately ships the schema first so it can be reviewed in isolation even if the downstream work slips.

## Test plan
- [x] `uv run pytest auction/tests/test_delivery_schemas_e2e.py -v` → 23 passed (4 new)
- [x] `uv run pytest auction/tests/ -q --ignore=auction/tests/integration` → 306 passed
- [x] `uv run mypy auction/delivery_schemas.py` → clean
- [x] `uv run ruff check auction/delivery_schemas.py` → clean

## Note for reviewer — pre-existing lint state
`auction/tests/test_delivery_schemas_e2e.py` already fails `uv run ruff check` on `main` with 68 errors (unused `pytest` import, unsorted imports, S311 random warnings on every generator function). This PR adds 2 more S311 instances matching the existing style of the file. Lint cleanup is out of scope here — flagging so it's not a surprise if CI runs ruff on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)