### PR TITLE
Fix CI failures: real bugs + annotations + format, no false-positive silencing

### DIFF
--- a/auction/api.py
+++ b/auction/api.py
@@ -226,6 +226,5 @@ def create_api_router(engine: AuctionEngine) -> APIRouter:
 
     return router
 
-
     # CORS is handled at the Cloudflare Worker and mcp_server.py levels.
     # Removed unused add_cors() — see IMP-032.

--- a/auction/contracts.py
+++ b/auction/contracts.py
@@ -23,10 +23,10 @@ EAS_SCHEMA_UID = "0x70a6cca5fbf857df1196dbbf7b0e460ff38f83788e3338a2c96cbb6feb3d
 # USDC token addresses by chain ID
 # ---------------------------------------------------------------------------
 USDC_ADDRESSES = {
-    8453: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",      # Base mainnet
-    1: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",          # Ethereum mainnet
-    84532: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",      # Base Sepolia
-    11155111: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",   # Eth Sepolia
+    8453: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",  # Base mainnet
+    1: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",  # Ethereum mainnet
+    84532: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",  # Base Sepolia
+    11155111: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",  # Eth Sepolia
 }
 
 # ---------------------------------------------------------------------------

--- a/auction/core.py
+++ b/auction/core.py
@@ -30,6 +30,7 @@ def haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     a = math.sin(dlat / 2) ** 2 + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.sin(dlon / 2) ** 2
     return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
+
 # ---------------------------------------------------------------------------
 # Optional eth_account import for Ed25519 signing (v1.0)
 # Falls back to HMAC-only mode if not installed.

--- a/auction/deliverable_qa.py
+++ b/auction/deliverable_qa.py
@@ -223,7 +223,7 @@ def validate_delivery_schema(
     # Type check
     expected_type = schema.get("type")
     if expected_type:
-        type_map = {
+        type_map: dict[str, type | tuple[type, ...]] = {
             "object": dict,
             "array": list,
             "string": str,

--- a/auction/engine.py
+++ b/auction/engine.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from dataclasses import dataclass, field
-from datetime import UTC
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
@@ -224,8 +224,6 @@ class AuctionEngine:
             delivery = None
             dl = row.get("delivery")
             if dl is not None:
-                from datetime import datetime
-
                 delivered_at = dl.get("delivered_at")
                 if isinstance(delivered_at, str):
                     delivered_at = datetime.fromisoformat(delivered_at)
@@ -586,6 +584,7 @@ class AuctionEngine:
         if isinstance(cap_req, dict) and "delivery_schema" not in cap_req:
             try:
                 from auction.delivery_schemas import get_delivery_schema
+
                 schema = get_delivery_schema(task.task_category)
                 cap_req["delivery_schema"] = schema
             except ImportError:
@@ -615,16 +614,16 @@ class AuctionEngine:
 
             # Geographic hard cutoff — robot won't bid outside service radius
             if task.latitude is not None and task.longitude is not None:
-                robot_lat = getattr(robot, '_latitude', None)
-                robot_lng = getattr(robot, '_longitude', None)
-                robot_radius = getattr(robot, '_service_radius_km', None)
+                robot_lat = getattr(robot, "_latitude", None)
+                robot_lng = getattr(robot, "_longitude", None)
+                robot_radius = getattr(robot, "_service_radius_km", None)
                 if robot_lat is not None and robot_lng is not None and robot_radius is not None:
                     dist = haversine_km(robot_lat, robot_lng, task.latitude, task.longitude)
                     if dist > robot_radius:
                         reasons_list.append(f"out_of_range:{dist:.0f}km>{robot_radius}km")
 
             # Busy state — robot is executing another task
-            busy_until = getattr(robot, '_busy_until', None)
+            busy_until = getattr(robot, "_busy_until", None)
             if busy_until is not None and busy_until > datetime.now(UTC):
                 remaining = (busy_until - datetime.now(UTC)).total_seconds()
                 reasons_list.append(f"busy:{remaining:.0f}s_remaining")
@@ -811,20 +810,28 @@ class AuctionEngine:
 
         # Set robot busy — cannot bid on other tasks until this one completes
         # Duration based on task type (see PLAN_100_ROBOT_FLEET.md Section 10)
-        import datetime as _dt
         task_cat = record.task.task_category
         duration_map = {
-            "env_sensing": 15, "sensor_reading": 15,  # seconds (in-situ)
-            "topo_survey": 60 * 60, "aerial_survey": 45 * 60, "corridor_survey": 2 * 60 * 60,
-            "subsurface_scan": 90 * 60, "utility_detection": 90 * 60,
-            "visual_inspection": 30 * 60, "progress_monitoring": 45 * 60,
-            "bridge_inspection": 60 * 60, "thermal_inspection": 30 * 60,
-            "as_built": 2 * 60 * 60, "confined_space": 45 * 60,
-            "volumetric": 30 * 60, "control_survey": 60 * 60,
-            "site_survey": 60 * 60, "environmental_survey": 45 * 60,
+            "env_sensing": 15,
+            "sensor_reading": 15,  # seconds (in-situ)
+            "topo_survey": 60 * 60,
+            "aerial_survey": 45 * 60,
+            "corridor_survey": 2 * 60 * 60,
+            "subsurface_scan": 90 * 60,
+            "utility_detection": 90 * 60,
+            "visual_inspection": 30 * 60,
+            "progress_monitoring": 45 * 60,
+            "bridge_inspection": 60 * 60,
+            "thermal_inspection": 30 * 60,
+            "as_built": 2 * 60 * 60,
+            "confined_space": 45 * 60,
+            "volumetric": 30 * 60,
+            "control_survey": 60 * 60,
+            "site_survey": 60 * 60,
+            "environmental_survey": 45 * 60,
         }
         busy_seconds = duration_map.get(task_cat, 30 * 60)  # default 30 min
-        robot._busy_until = _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(seconds=busy_seconds)
+        robot._busy_until = datetime.now(UTC) + timedelta(seconds=busy_seconds)
         log("BUSY", f"{robot_id} busy for {busy_seconds}s (task: {task_cat})")
 
         # BIDDING -> BID_ACCEPTED
@@ -1297,8 +1304,6 @@ class AuctionEngine:
         # Auto-accept deadline as ISO timestamp (REC-20)
         auto_accept_deadline = None
         if timer_active:
-            from datetime import timedelta
-
             if record.delivery is not None:
                 auto_accept_deadline = (
                     record.delivery.delivered_at + timedelta(seconds=record.task.auto_accept_seconds)

--- a/auction/mcp_robot_adapter.py
+++ b/auction/mcp_robot_adapter.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import Any
 
 import httpx
 
@@ -59,6 +60,7 @@ class MCPRobotAdapter:
         self._known_tools: list[str] = list(mcp_tools) if mcp_tools else []
 
         # Build sensor metadata from on-chain sensors list or fall back to defaults
+        sensor_list: list[dict[str, Any]]
         if sensors:
             sensor_list = [{"type": s.strip()} for s in sensors if s.strip()]
         else:
@@ -197,6 +199,7 @@ class MCPRobotAdapter:
             line = line.strip()
             if line.startswith("data: "):
                 import json
+
                 msg = json.loads(line[6:])
                 if "result" in msg:
                     return msg["result"]
@@ -221,6 +224,7 @@ class MCPRobotAdapter:
 
         if loop is not None and loop.is_running():
             import concurrent.futures
+
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 result = pool.submit(asyncio.run, self._bid_async(task)).result(timeout=30)
         else:
@@ -249,20 +253,22 @@ class MCPRobotAdapter:
     async def _bid_async(self, task: Task) -> Bid | None:
         """Async implementation of bid request."""
         bid_tool = self._resolve_marketplace_tool("robot_submit_bid")
-        result = await self._mcp_call("tools/call", {
-            "name": bid_tool,
-            "arguments": {
-                "task_description": task.description,
-                "task_category": task.task_category,
-                "budget_ceiling": float(task.budget_ceiling),
-                "sla_seconds": task.sla_seconds,
-                "capability_requirements": task.capability_requirements,
+        result = await self._mcp_call(
+            "tools/call",
+            {
+                "name": bid_tool,
+                "arguments": {
+                    "task_description": task.description,
+                    "task_category": task.task_category,
+                    "budget_ceiling": float(task.budget_ceiling),
+                    "sla_seconds": task.sla_seconds,
+                    "capability_requirements": task.capability_requirements,
+                },
             },
-        })
+        )
 
         if not result:
             return None
-
 
         # Parse structured content or text content
         content = result
@@ -270,6 +276,7 @@ class MCPRobotAdapter:
             content = result["structuredContent"]
         elif "content" in result and isinstance(result["content"], list):
             import json
+
             for block in result["content"]:
                 if block.get("type") == "text":
                     try:
@@ -291,9 +298,7 @@ class MCPRobotAdapter:
         # Enrich capability metadata from bid response
         caps = content.get("capabilities_offered", [])
         if caps:
-            self.capability_metadata["sensors"] = [
-                {"type": s} if isinstance(s, str) else s for s in caps
-            ]
+            self.capability_metadata["sensors"] = [{"type": s} if isinstance(s, str) else s for s in caps]
 
         bid_hash = sign_bid(self.robot_id, task.request_id, price, self.signing_key)
 
@@ -334,8 +339,9 @@ class MCPRobotAdapter:
                 if tools_result and isinstance(tools_result, dict):
                     tool_entries = tools_result.get("tools", [])
                     self._known_tools = [t["name"] for t in tool_entries if isinstance(t, dict) and "name" in t]
-                    log.info("Discovered %d tools from %s: %s",
-                             len(self._known_tools), self.robot_id, self._known_tools[:5])
+                    log.info(
+                        "Discovered %d tools from %s: %s", len(self._known_tools), self.robot_id, self._known_tools[:5]
+                    )
             except Exception as e:
                 log.warning("Tool discovery failed for %s: %s", self.robot_id, e)
 
@@ -351,15 +357,18 @@ class MCPRobotAdapter:
 
         start = datetime.now(UTC)
         num_waypoints = 3
-        readings = []
+        readings: list[dict[str, Any]] = []
 
         # Waypoint-by-waypoint execution using resolved tools
         for wp in range(1, num_waypoints + 1):
             if move_tool:
-                move_result = await self._mcp_call("tools/call", {
-                    "name": move_tool,
-                    "arguments": {"direction": "forward"},
-                })
+                move_result = await self._mcp_call(
+                    "tools/call",
+                    {
+                        "name": move_tool,
+                        "arguments": {"direction": "forward"},
+                    },
+                )
                 move_ok = move_result and not move_result.get("isError")
                 if move_ok:
                     log.info("Waypoint %d: moved forward via %s", wp, move_tool)
@@ -370,15 +379,19 @@ class MCPRobotAdapter:
             await asyncio.sleep(1.0)
             if not sensor_tool:
                 break  # no sensor tool — skip to robot_execute_task fallback
-            sensor_result = await self._mcp_call("tools/call", {
-                "name": sensor_tool,
-                "arguments": {},
-            })
+            sensor_result = await self._mcp_call(
+                "tools/call",
+                {
+                    "name": sensor_tool,
+                    "arguments": {},
+                },
+            )
 
             if sensor_result and not sensor_result.get("isError"):
                 sensor_data = sensor_result.get("structuredContent") or {}
                 if not sensor_data and sensor_result.get("content"):
                     import json
+
                     for block in sensor_result["content"]:
                         if block.get("type") == "text":
                             try:
@@ -386,14 +399,15 @@ class MCPRobotAdapter:
                             except (json.JSONDecodeError, KeyError):
                                 pass
 
-                readings.append({
-                    "waypoint": wp,
-                    "temperature_c": round(float(sensor_data.get("temperature", 0)), 1),
-                    "humidity_pct": round(float(sensor_data.get("humidity", 0)), 1),
-                    "timestamp": datetime.now(UTC).isoformat(),
-                })
-                log.info("Waypoint %d: %.1f°C, %.1f%%",
-                         wp, readings[-1]["temperature_c"], readings[-1]["humidity_pct"])
+                readings.append(
+                    {
+                        "waypoint": wp,
+                        "temperature_c": round(float(sensor_data.get("temperature", 0)), 1),
+                        "humidity_pct": round(float(sensor_data.get("humidity", 0)), 1),
+                        "timestamp": datetime.now(UTC).isoformat(),
+                    }
+                )
+                log.info("Waypoint %d: %.1f°C, %.1f%%", wp, readings[-1]["temperature_c"], readings[-1]["humidity_pct"])
             else:
                 log.warning("Waypoint %d: sensor read failed", wp)
 
@@ -405,19 +419,23 @@ class MCPRobotAdapter:
         if not readings:
             log.warning("No waypoint readings — falling back to robot_execute_task")
             exec_tool = self._resolve_marketplace_tool("robot_execute_task")
-            fallback = await self._mcp_call("tools/call", {
-                "name": exec_tool,
-                "arguments": {
-                    "task_id": task.request_id,
-                    "task_description": task.description,
-                    "parameters": task.capability_requirements,
+            fallback = await self._mcp_call(
+                "tools/call",
+                {
+                    "name": exec_tool,
+                    "arguments": {
+                        "task_id": task.request_id,
+                        "task_description": task.description,
+                        "parameters": task.capability_requirements,
+                    },
                 },
-            })
-            content = {}
+            )
+            content: dict[str, Any] = {}
             if fallback:
                 content = fallback.get("structuredContent") or {}
                 if not content and fallback.get("content"):
                     import json
+
                     for block in fallback["content"]:
                         if block.get("type") == "text":
                             try:
@@ -440,23 +458,25 @@ class MCPRobotAdapter:
 
             # Legacy: parse into waypoint/temperature format
             for r in dd.get("readings", []):
-                readings.append({
-                    "waypoint": len(readings) + 1,
-                    "temperature_c": round(float(r.get("temperature_c", r.get("value", 0))), 1),
-                    "humidity_pct": round(float(r.get("humidity_pct", 0)), 1),
-                    "timestamp": r.get("timestamp", now.isoformat()),
-                })
+                readings.append(
+                    {
+                        "waypoint": len(readings) + 1,
+                        "temperature_c": round(float(r.get("temperature_c", r.get("value", 0))), 1),
+                        "humidity_pct": round(float(r.get("humidity_pct", 0)), 1),
+                        "timestamp": r.get("timestamp", now.isoformat()),
+                    }
+                )
 
         if not readings:
             # Final fallback — no data at all
             readings = [{"waypoint": 1, "temperature_c": 0, "humidity_pct": 0, "timestamp": now.isoformat()}]
 
-        temps = [r["temperature_c"] for r in readings if r.get("temperature_c")]
-        humids = [r["humidity_pct"] for r in readings if r.get("humidity_pct")]
+        temps: list[float] = [float(r["temperature_c"]) for r in readings if r.get("temperature_c")]
+        humids: list[float] = [float(r["humidity_pct"]) for r in readings if r.get("humidity_pct")]
         summary = (
             f"{len(readings)} waypoints measured by {self.robot_id}. "
-            f"Temp: {min(temps, default=0):.1f}-{max(temps, default=0):.1f}°C, "
-            f"Humidity: {min(humids, default=0):.1f}-{max(humids, default=0):.1f}%"
+            f"Temp: {min(temps, default=0.0):.1f}-{max(temps, default=0.0):.1f}°C, "
+            f"Humidity: {min(humids, default=0.0):.1f}-{max(humids, default=0.0):.1f}%"
         )
 
         data = {

--- a/auction/mcp_tools.py
+++ b/auction/mcp_tools.py
@@ -18,6 +18,7 @@ auction mode is enabled.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from datetime import UTC
 from decimal import Decimal
@@ -27,6 +28,8 @@ from mcp.server.fastmcp import FastMCP
 
 from auction.core import VALID_TASK_CATEGORIES, TaskState
 from auction.engine import AuctionEngine
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -151,13 +154,31 @@ DEFAULT_CHAIN = "base-mainnet"
 # EAS (Ethereum Attestation Service) contract ABI — attest function only
 EAS_ABI = [
     {
-        "inputs": [{"components": [{"name": "schema", "type": "bytes32"},
-            {"components": [{"name": "recipient", "type": "address"}, {"name": "expirationTime", "type": "uint64"},
-             {"name": "revocable", "type": "bool"}, {"name": "refUID", "type": "bytes32"},
-             {"name": "data", "type": "bytes"}, {"name": "value", "type": "uint256"}],
-            "name": "data", "type": "tuple"}], "name": "request", "type": "tuple"}],
-        "name": "attest", "outputs": [{"name": "", "type": "bytes32"}],
-        "stateMutability": "payable", "type": "function",
+        "inputs": [
+            {
+                "components": [
+                    {"name": "schema", "type": "bytes32"},
+                    {
+                        "components": [
+                            {"name": "recipient", "type": "address"},
+                            {"name": "expirationTime", "type": "uint64"},
+                            {"name": "revocable", "type": "bool"},
+                            {"name": "refUID", "type": "bytes32"},
+                            {"name": "data", "type": "bytes"},
+                            {"name": "value", "type": "uint256"},
+                        ],
+                        "name": "data",
+                        "type": "tuple",
+                    },
+                ],
+                "name": "request",
+                "type": "tuple",
+            }
+        ],
+        "name": "attest",
+        "outputs": [{"name": "", "type": "bytes32"}],
+        "stateMutability": "payable",
+        "type": "function",
     },
 ]
 
@@ -750,9 +771,7 @@ def register_auction_tools(
         try:
             from auction.rfp_processor import process_rfp
 
-            specs = await asyncio.to_thread(
-                process_rfp, rfp_text, jurisdiction, site_info or None
-            )
+            specs = await asyncio.to_thread(process_rfp, rfp_text, jurisdiction, site_info or None)
 
             warnings = []
             if not site_info.get("coordinates"):
@@ -994,8 +1013,8 @@ def register_auction_tools(
                     "pki_providers": ["IdenTrust (AATL-listed)", "GlobalSign", "DigiCert"],
                     "estimated_cost": "$100-200/year per certificate",
                     "note": "Standard DocuSign or Adobe Sign e-signatures do NOT satisfy PKI requirements in these states. "
-                            "Operators delivering PLS-stamped work in OH, VA, NJ, or FL must obtain a PKI certificate from an "
-                            "AATL-listed Certificate Authority.",
+                    "Operators delivering PLS-stamped work in OH, VA, NJ, or FL must obtain a PKI certificate from an "
+                    "AATL-listed Certificate Authority.",
                 }
             return result
         except (ValueError, Exception) as exc:
@@ -1312,11 +1331,15 @@ def register_auction_tools(
                         if update_fields:
                             engine._operator_registry.update_profile(op.operator_id, **update_fields)
                         break
-            except Exception:
-                pass  # Registry update is best-effort
+            except Exception as exc:
+                log.warning("operator registry update (best-effort) failed for %s: %s", robot_id, exc)
 
         if not changes:
-            return {"robot_id": robot_id, "status": "no_changes", "message": "No fields to update. Provide at least one field with a new value."}
+            return {
+                "robot_id": robot_id,
+                "status": "no_changes",
+                "message": "No fields to update. Provide at least one field with a new value.",
+            }
 
         return {
             "robot_id": robot_id,
@@ -1371,7 +1394,9 @@ def register_auction_tools(
         if not name or not name.strip():
             return _error_response_structured("INVALID_NAME", "name is required.", "Provide a non-empty robot name.")
         if not company_name or not company_name.strip():
-            return _error_response_structured("INVALID_COMPANY", "company_name is required.", "Provide a company or operator name.")
+            return _error_response_structured(
+                "INVALID_COMPANY", "company_name is required.", "Provide a company or operator name."
+            )
         if not location or not location.strip():
             return _error_response_structured("INVALID_LOCATION", "location is required.", "e.g. Detroit, MI")
         # Validate equipment_type — must be registered in SENSOR_TO_CATEGORY.
@@ -1398,7 +1423,11 @@ def register_auction_tools(
                 ),
             )
         if not (0.0 < bid_pct <= 1.0):
-            return _error_response_structured("INVALID_BID_PCT", "bid_pct must be between 0 (exclusive) and 1 (inclusive).", "Typical values: 0.70–0.95")
+            return _error_response_structured(
+                "INVALID_BID_PCT",
+                "bid_pct must be between 0 (exclusive) and 1 (inclusive).",
+                "Typical values: 0.70–0.95",
+            )
         if min_bid_cents < 1:
             return _error_response_structured("INVALID_MIN_BID", "min_bid_cents must be >= 1.", "Use 50 or higher.")
 
@@ -1421,11 +1450,10 @@ def register_auction_tools(
         marketplace_endpoint = marketplace_base + "/mcp"
         # The robot's MCP endpoint — where it actually lives (not the marketplace)
         robot_mcp_url = mcp_endpoint_url or "https://fleet.yakrover.online/fakerover/mcp"
-        # Equipment (sensors AND platforms) drives task_category routing,
-        # but only actual measurement sensors belong in the sensors list.
+        # Equipment (sensors AND platforms) drives task_category routing.
         # All types here are known (validated above); no silent fallback.
+        # The sensor vs platform split happens inside _blocking_register below.
         all_equipment_list = equipment_types if equipment_types else [equipment_type]
-        all_sensor_list = [e for e in all_equipment_list if e not in PLATFORM_EQUIPMENT]
         task_categories = sorted({SENSOR_TO_CATEGORY[s] for s in all_equipment_list})
         task_category = ",".join(task_categories)
 
@@ -1433,6 +1461,7 @@ def register_auction_tools(
             # 1. Operator profile
             if not hasattr(engine, "_operator_registry") or engine._operator_registry is None:
                 from auction.operator_registry import OperatorRegistry
+
                 engine._operator_registry = OperatorRegistry()
 
             profile = engine._operator_registry.register(
@@ -1463,6 +1492,7 @@ def register_auction_tools(
             robot_tools = []
             try:
                 from agent0_sdk import SDK
+
                 sdk = SDK(
                     chainId=cfg["chain_id"],
                     rpcUrl=cfg["rpc"],
@@ -1475,8 +1505,11 @@ def register_auction_tools(
                 agent.setMCP(robot_mcp_url, auto_fetch=False)
 
                 mcp_ep = next(
-                    (ep for ep in agent.registration_file.endpoints
-                     if hasattr(ep, "type") and str(ep.type).lower().endswith("mcp")),
+                    (
+                        ep
+                        for ep in agent.registration_file.endpoints
+                        if hasattr(ep, "type") and str(ep.type).lower().endswith("mcp")
+                    ),
                     None,
                 )
                 if mcp_ep is None:
@@ -1486,23 +1519,36 @@ def register_auction_tools(
                 robot_tools = []
                 try:
                     import httpx
+
                     probe = httpx.post(
                         robot_mcp_url,
-                        json={"jsonrpc": "2.0", "method": "initialize",
-                              "params": {"protocolVersion": "2025-03-26", "capabilities": {},
-                                         "clientInfo": {"name": "registrar", "version": "1.0"}}, "id": 1},
-                        headers={"Accept": "text/event-stream",
-                                 "Authorization": f"Bearer {os.environ.get('FLEET_MCP_TOKEN', '')}"},
+                        json={
+                            "jsonrpc": "2.0",
+                            "method": "initialize",
+                            "params": {
+                                "protocolVersion": "2025-03-26",
+                                "capabilities": {},
+                                "clientInfo": {"name": "registrar", "version": "1.0"},
+                            },
+                            "id": 1,
+                        },
+                        headers={
+                            "Accept": "text/event-stream",
+                            "Authorization": f"Bearer {os.environ.get('FLEET_MCP_TOKEN', '')}",
+                        },
                         timeout=10.0,
                     )
                     if probe.status_code == 200:
                         import json as _json
+
                         tools_resp = httpx.post(
                             robot_mcp_url,
                             json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 2},
-                            headers={"Accept": "text/event-stream",
-                                     "Mcp-Session-Id": probe.headers.get("mcp-session-id", ""),
-                                     "Authorization": f"Bearer {os.environ.get('FLEET_MCP_TOKEN', '')}"},
+                            headers={
+                                "Accept": "text/event-stream",
+                                "Mcp-Session-Id": probe.headers.get("mcp-session-id", ""),
+                                "Authorization": f"Bearer {os.environ.get('FLEET_MCP_TOKEN', '')}",
+                            },
                             timeout=10.0,
                         )
                         for line in tools_resp.text.splitlines():
@@ -1512,10 +1558,10 @@ def register_auction_tools(
                                     for t in msg.get("result", {}).get("tools", []):
                                         if isinstance(t, dict) and "name" in t:
                                             robot_tools.append(t["name"])
-                                except Exception:
-                                    pass
-                except Exception:
-                    pass  # tool discovery failed — will use fallback defaults
+                                except Exception as exc:
+                                    log.debug("skipped malformed tools/list SSE line for %s: %s", robot_mcp_url, exc)
+                except Exception as exc:
+                    log.info("tool discovery probe failed for %s (falling back to defaults): %s", robot_mcp_url, exc)
 
                 mcp_ep.meta["mcpTools"] = robot_tools if robot_tools else ["robot_submit_bid", "robot_execute_task"]
                 mcp_ep.meta["fleetEndpoint"] = marketplace_endpoint
@@ -1561,6 +1607,7 @@ def register_auction_tools(
 
                 # Step 1: Mint token with on-chain metadata (no IPFS URI yet)
                 import time as _time
+
                 metadata_entries = agent._collectMetadataForRegistration()
                 tx1_hash = sdk.web3_client.transact_contract(
                     sdk.identity_registry,
@@ -1641,6 +1688,7 @@ def register_auction_tools(
                 # Always create MCPRobotAdapter — it handles unreachable endpoints
                 # gracefully (bid returns None, execution falls back to robot_execute_task)
                 from auction.mcp_robot_adapter import MCPRobotAdapter
+
                 bearer = os.environ.get("FLEET_MCP_TOKEN", "")
                 robot = MCPRobotAdapter(
                     robot_id=name,
@@ -1731,7 +1779,9 @@ def register_auction_tools(
                 break
         if chain_cfg is None:
             valid_ids = [c["chain_id"] for c in CHAIN_CONFIG.values()]
-            return _error_response_structured("INVALID_CHAIN", f"chain_id {chain_id} not in CHAIN_CONFIG. Valid: {valid_ids}", "")
+            return _error_response_structured(
+                "INVALID_CHAIN", f"chain_id {chain_id} not in CHAIN_CONFIG. Valid: {valid_ids}", ""
+            )
 
         # Pick explorer based on network
         explorer_base = "https://base-sepolia.easscan.org" if chain_id == 84532 else "https://base.easscan.org"
@@ -1741,9 +1791,7 @@ def register_auction_tools(
             from web3 import Web3 as _Web3
 
             w3 = _Web3(_Web3.HTTPProvider(chain_cfg["rpc"]))
-            eas = w3.eth.contract(
-                address=_Web3.to_checksum_address(EAS_ADDRESS), abi=EAS_ABI
-            )
+            eas = w3.eth.contract(address=_Web3.to_checksum_address(EAS_ADDRESS), abi=EAS_ABI)
             account = w3.eth.account.from_key(signer_key)
 
             encoded_data = _eth_abi.encode(
@@ -1755,17 +1803,27 @@ def register_auction_tools(
                 (
                     bytes.fromhex(EAS_SCHEMA_UID[2:]),
                     (
-                        _Web3.to_checksum_address(attester_address if attester_address.startswith("0x") else "0x0000000000000000000000000000000000000000"),
-                        0, True, b"\x00" * 32, encoded_data, 0,
+                        _Web3.to_checksum_address(
+                            attester_address
+                            if attester_address.startswith("0x")
+                            else "0x0000000000000000000000000000000000000000"
+                        ),
+                        0,
+                        True,
+                        b"\x00" * 32,
+                        encoded_data,
+                        0,
                     ),
                 )
-            ).build_transaction({
-                "from": account.address,
-                "nonce": w3.eth.get_transaction_count(account.address),
-                "gasPrice": w3.eth.gas_price,
-                "chainId": chain_id,
-                "value": 0,
-            })
+            ).build_transaction(
+                {
+                    "from": account.address,
+                    "nonce": w3.eth.get_transaction_count(account.address),
+                    "gasPrice": w3.eth.gas_price,
+                    "chainId": chain_id,
+                    "value": 0,
+                }
+            )
 
             signed = w3.eth.account.sign_transaction(tx, signer_key)
             tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
@@ -2107,7 +2165,11 @@ def register_auction_tools(
             request_id: Associated task request_id if one was posted (optional).
         """
         if engine.store is None:
-            return {"error": True, "error_code": "NO_STORE", "message": "SQLite persistence not configured. Set AUCTION_DB_PATH."}
+            return {
+                "error": True,
+                "error_code": "NO_STORE",
+                "message": "SQLite persistence not configured. Set AUCTION_DB_PATH.",
+            }
 
         row_id = engine.store.save_unmet_demand(
             task_category,
@@ -2150,7 +2212,11 @@ def register_auction_tools(
             limit: Maximum results to return (default 20).
         """
         if engine.store is None:
-            return {"error": True, "error_code": "NO_STORE", "message": "SQLite persistence not configured. Set AUCTION_DB_PATH."}
+            return {
+                "error": True,
+                "error_code": "NO_STORE",
+                "message": "SQLite persistence not configured. Set AUCTION_DB_PATH.",
+            }
 
         signals = engine.store.get_demand_signals(
             task_category=task_category or None,
@@ -2161,7 +2227,7 @@ def register_auction_tools(
         )
 
         # Aggregate summary
-        categories = {}
+        categories: dict[str, int] = {}
         for s in signals:
             cat = s["task_category"]
             categories[cat] = categories.get(cat, 0) + 1

--- a/auction/mock_fleet.py
+++ b/auction/mock_fleet.py
@@ -149,19 +149,22 @@ def _generate_env_sensing_data(robot_id: str, task: Task) -> DeliveryPayload:
     has_delivery_schema = bool(task.capability_requirements.get("delivery_schema"))
     if task.task_category == "env_sensing" and has_delivery_schema:
         num_waypoints = 3
-        readings = []
+        readings: list[dict[str, Any]] = []
         for wp in range(1, num_waypoints + 1):
-            readings.append({
-                "waypoint": wp,
-                "temperature_c": round(21.0 + random.uniform(-2.0, 3.0), 1),
-                "humidity_pct": round(45.0 + random.uniform(-5.0, 10.0), 1),
-                "timestamp": now.isoformat(),
-            })
+            readings.append(
+                {
+                    "waypoint": wp,
+                    "temperature_c": round(21.0 + random.uniform(-2.0, 3.0), 1),
+                    "humidity_pct": round(45.0 + random.uniform(-5.0, 10.0), 1),
+                    "timestamp": now.isoformat(),
+                }
+            )
+        avg_temp = sum(float(r["temperature_c"]) for r in readings) / len(readings)
+        avg_humidity = sum(float(r["humidity_pct"]) for r in readings) / len(readings)
         data: dict[str, Any] = {
             "readings": readings,
             "summary": f"Environmental scan complete. {num_waypoints} waypoints measured. "
-                       f"Avg temp: {sum(r['temperature_c'] for r in readings)/len(readings):.1f}°C, "
-                       f"Avg humidity: {sum(r['humidity_pct'] for r in readings)/len(readings):.1f}%",
+            f"Avg temp: {avg_temp:.1f}°C, Avg humidity: {avg_humidity:.1f}%",
             "duration_seconds": round(elapsed, 1),
         }
     else:

--- a/auction/operator_registry.py
+++ b/auction/operator_registry.py
@@ -203,14 +203,18 @@ class OperatorRegistry:
             account_data = stripe_service.get_account(profile.stripe_account_id)
             if account_data.get("error"):
                 if use_test_account_fallback:
-                    stripe_warning = f"Stripe account lookup failed ({account_data['error']}). Using test account for demo."
+                    stripe_warning = (
+                        f"Stripe account lookup failed ({account_data['error']}). Using test account for demo."
+                    )
                     profile.stripe_account_id = self.TEST_STRIPE_ACCOUNT
                 else:
                     issues.append(f"Stripe account error: {account_data['error']}")
             elif not account_data.get("payouts_enabled", False):
                 disabled_reason = account_data.get("requirements", {}).get("disabled_reason", "unknown")
                 if use_test_account_fallback:
-                    stripe_warning = f"Stripe payouts not enabled (reason: {disabled_reason}). Using test account for demo."
+                    stripe_warning = (
+                        f"Stripe payouts not enabled (reason: {disabled_reason}). Using test account for demo."
+                    )
                     profile.stripe_account_id = self.TEST_STRIPE_ACCOUNT
                 else:
                     issues.append(
@@ -245,8 +249,13 @@ class OperatorRegistry:
         """Update an existing operator profile. Only provided fields are changed."""
         profile = self._get(operator_id)
         allowed = {
-            "company_name", "contact_name", "contact_email", "location",
-            "coverage_states", "max_range_miles", "stripe_account_id",
+            "company_name",
+            "contact_name",
+            "contact_email",
+            "location",
+            "coverage_states",
+            "max_range_miles",
+            "stripe_account_id",
         }
         updated = []
         for k, v in fields.items():

--- a/auction/rfp_processor.py
+++ b/auction/rfp_processor.py
@@ -120,17 +120,36 @@ def process_rfp(
     survey_types = []
 
     # Environmental / sensor monitoring (non-survey tasks)
-    if any(kw in rfp_lower for kw in [
-        "temperature", "humidity", "environmental monitor", "climate assess",
-        "sensor reading", "env_sensing", "indoor climate", "server room",
-        "air quality", "thermal comfort", "data logging",
-    ]):
+    if any(
+        kw in rfp_lower
+        for kw in [
+            "temperature",
+            "humidity",
+            "environmental monitor",
+            "climate assess",
+            "sensor reading",
+            "env_sensing",
+            "indoor climate",
+            "server room",
+            "air quality",
+            "thermal comfort",
+            "data logging",
+        ]
+    ):
         survey_types.append("env_sensing")
     # Visual / camera inspection
-    if any(kw in rfp_lower for kw in [
-        "visual inspection", "camera inspect", "photo document", "crack detection",
-        "condition assess", "defect", "visual_inspection",
-    ]):
+    if any(
+        kw in rfp_lower
+        for kw in [
+            "visual inspection",
+            "camera inspect",
+            "photo document",
+            "crack detection",
+            "condition assess",
+            "defect",
+            "visual_inspection",
+        ]
+    ):
         survey_types.append("visual_inspection")
     # Construction survey types
     if any(kw in rfp_lower for kw in ["topographic", "topo survey", "surface survey", "corridor survey"]):
@@ -423,7 +442,7 @@ def _build_task_spec(
 # ---------------------------------------------------------------------------
 
 
-    # _load_reference() is defined at module level (line 26) — no redefinition needed
+# _load_reference() is defined at module level (line 26) — no redefinition needed
 
 
 def _process_rfp_with_llm(

--- a/auction/store.py
+++ b/auction/store.py
@@ -730,8 +730,6 @@ class SyncTaskStore:
 
     def save_event(self, event: dict) -> None:
         """Persist a structured event to the events table."""
-        import json as _json
-
         db = self._conn()
         db.execute(
             """INSERT INTO events
@@ -743,7 +741,7 @@ class SyncTaskStore:
                 event.get("request_id"),
                 event.get("actor_id"),
                 event.get("actor_role", "system"),
-                _json.dumps(event.get("data", {})),
+                json.dumps(event.get("data", {})),
                 event["timestamp"],
             ),
         )
@@ -759,8 +757,6 @@ class SyncTaskStore:
         limit: int = 50,
     ) -> list[dict]:
         """Query events with optional filters."""
-        import json as _json
-
         db = self._conn()
         clauses: list[str] = []
         params: list[str] = []

--- a/auction/tests/test_core.py
+++ b/auction/tests/test_core.py
@@ -223,9 +223,7 @@ class TestHardConstraints:
 
     def test_check_hard_constraints_certifications(self):
         """certifications_required gates operators without required certs."""
-        task = make_task(capability_requirements={
-            "hard": {"certifications_required": ["licensed_surveyor"]}
-        })
+        task = make_task(capability_requirements={"hard": {"certifications_required": ["licensed_surveyor"]}})
         # Robot without certification
         robot_no_cert = {"sensors": [], "certifications": []}
         eligible, reasons = check_hard_constraints(task, robot_no_cert)

--- a/auction/tests/test_delivery_schemas_e2e.py
+++ b/auction/tests/test_delivery_schemas_e2e.py
@@ -7,8 +7,7 @@ would return, then validates it against the corresponding delivery schema.
 import random
 import time
 
-import pytest
-
+from auction.deliverable_qa import validate_delivery_schema
 from auction.delivery_schemas import (
     AERIAL_LIDAR_SCHEMA,
     AERIAL_PHOTO_SCHEMA,
@@ -22,8 +21,6 @@ from auction.delivery_schemas import (
     GROUND_LIDAR_SCHEMA,
     get_delivery_schema,
 )
-from auction.deliverable_qa import validate_delivery_schema
-
 
 # ── Simulated data generators (mirrors category_server.py) ────────
 
@@ -48,7 +45,14 @@ def make_aerial_lidar_delivery():
             "point_count": int(area * density),
             "density_pts_m2": density,
             "area_m2": area,
-            "classifications": ["ground", "low_vegetation", "medium_vegetation", "high_vegetation", "building", "noise"],
+            "classifications": [
+                "ground",
+                "low_vegetation",
+                "medium_vegetation",
+                "high_vegetation",
+                "building",
+                "noise",
+            ],
             "bounding_box": {"min": sim_gps(), "max": sim_gps()},
         },
         "quality_metrics": {
@@ -95,13 +99,15 @@ def make_aerial_photo_delivery():
 def make_ground_gpr_delivery():
     utilities = []
     for _ in range(random.randint(2, 8)):
-        utilities.append({
-            "type": random.choice(["water", "sewer", "electric", "gas", "telecom"]),
-            "depth_m": round(random.uniform(0.3, 2.5), 2),
-            "confidence": round(random.uniform(0.6, 0.98), 2),
-            "apwa_color": random.choice(["blue", "green", "red", "yellow", "orange"]),
-            "position": sim_gps(),
-        })
+        utilities.append(
+            {
+                "type": random.choice(["water", "sewer", "electric", "gas", "telecom"]),
+                "depth_m": round(random.uniform(0.3, 2.5), 2),
+                "confidence": round(random.uniform(0.6, 0.98), 2),
+                "apwa_color": random.choice(["blue", "green", "red", "yellow", "orange"]),
+                "position": sim_gps(),
+            }
+        )
     return {
         "scan_data": {
             "format": "DZT",
@@ -124,13 +130,15 @@ def make_ground_gpr_delivery():
 def make_aerial_thermal_delivery():
     anomalies = []
     for _ in range(random.randint(1, 5)):
-        anomalies.append({
-            "severity": random.choice(["low", "medium", "high", "critical"]),
-            "delta_t_c": round(random.uniform(2, 15), 1),
-            "area_m2": round(random.uniform(0.5, 20), 1),
-            "classification": random.choice(["moisture", "insulation_gap", "membrane_failure"]),
-            "position": sim_gps(),
-        })
+        anomalies.append(
+            {
+                "severity": random.choice(["low", "medium", "high", "critical"]),
+                "delta_t_c": round(random.uniform(2, 15), 1),
+                "area_m2": round(random.uniform(0.5, 20), 1),
+                "classification": random.choice(["moisture", "insulation_gap", "membrane_failure"]),
+                "position": sim_gps(),
+            }
+        )
     return {
         "thermal_mosaic": {
             "format": "RJPEG",
@@ -156,15 +164,17 @@ def make_aerial_thermal_delivery():
 def make_bridge_inspection_delivery():
     elements = []
     for elem in ["deck", "superstructure", "substructure", "bearings", "joints"]:
-        elements.append({
-            "element": elem,
-            "condition_state": random.randint(1, 4),
-            "quantity_pct": round(random.uniform(60, 100), 1),
-            "defects": random.sample(
-                ["spalling", "cracking", "corrosion", "delamination", "efflorescence"],
-                random.randint(0, 3),
-            ),
-        })
+        elements.append(
+            {
+                "element": elem,
+                "condition_state": random.randint(1, 4),
+                "quantity_pct": round(random.uniform(60, 100), 1),
+                "defects": random.sample(
+                    ["spalling", "cracking", "corrosion", "delamination", "efflorescence"],
+                    random.randint(0, 3),
+                ),
+            }
+        )
     return {
         "inspection_set": {
             "total_images": random.randint(100, 400),

--- a/auction/tests/test_fakerover_bid.py
+++ b/auction/tests/test_fakerover_bid.py
@@ -104,6 +104,16 @@ if not _INIT_PATH.exists():
         / "__init__.py"
     )
 
+# This test imports the fakerover plugin directly from the sibling yakrover-8004-mcp
+# repo. That's only available in a local dev setup with both repos checked out. CI
+# only has this repo checked out, so skip the module cleanly rather than error.
+if not _INIT_PATH.exists():
+    pytest.skip(
+        f"sibling repo not found at {_INIT_PATH} — these tests require a dev setup "
+        "with both yakrover-marketplace and yakrover-8004-mcp cloned side by side",
+        allow_module_level=True,
+    )
+
 spec = importlib.util.spec_from_file_location(_FAKEROVER_PKG, _INIT_PATH, submodule_search_locations=[])
 _mod = importlib.util.module_from_spec(spec)
 sys.modules[_FAKEROVER_PKG] = _mod

--- a/auction/tests/test_operator_registry.py
+++ b/auction/tests/test_operator_registry.py
@@ -204,44 +204,71 @@ class TestActivate:
         assert result["status"] == "pending"
         assert len(result["issues"]) == 4
 
-    def test_activate_stripe_payouts_disabled_with_fallback(self, registry: OperatorRegistry, registered_op: OperatorProfile) -> None:
+    def test_activate_stripe_payouts_disabled_with_fallback(
+        self, registry: OperatorRegistry, registered_op: OperatorProfile
+    ) -> None:
         """When Stripe payouts not enabled, falls back to test account."""
         self._prepare_for_activation(registry, registered_op)
 
         class MockStripe:
             stub_mode = False
-            def get_account(self, acct_id):
-                return {"payouts_enabled": False, "requirements": {"disabled_reason": "pending_verification"}}
 
-        result = registry.activate(registered_op.operator_id, stripe_service=MockStripe(), use_test_account_fallback=True)
+            def get_account(self, acct_id):
+                return {
+                    "payouts_enabled": False,
+                    "requirements": {"disabled_reason": "pending_verification"},
+                }
+
+        result = registry.activate(
+            registered_op.operator_id,
+            stripe_service=MockStripe(),
+            use_test_account_fallback=True,
+        )
         assert result["status"] == "active"
         assert "stripe_warning" in result
         assert "test account" in result["stripe_warning"].lower()
         assert registered_op.stripe_account_id == OperatorRegistry.TEST_STRIPE_ACCOUNT
 
-    def test_activate_stripe_payouts_disabled_no_fallback(self, registry: OperatorRegistry, registered_op: OperatorProfile) -> None:
+    def test_activate_stripe_payouts_disabled_no_fallback(
+        self, registry: OperatorRegistry, registered_op: OperatorProfile
+    ) -> None:
         """When Stripe payouts not enabled and no fallback, blocks activation."""
         self._prepare_for_activation(registry, registered_op)
 
         class MockStripe:
             stub_mode = False
-            def get_account(self, acct_id):
-                return {"payouts_enabled": False, "requirements": {"disabled_reason": "pending_verification"}}
 
-        result = registry.activate(registered_op.operator_id, stripe_service=MockStripe(), use_test_account_fallback=False)
+            def get_account(self, acct_id):
+                return {
+                    "payouts_enabled": False,
+                    "requirements": {"disabled_reason": "pending_verification"},
+                }
+
+        result = registry.activate(
+            registered_op.operator_id,
+            stripe_service=MockStripe(),
+            use_test_account_fallback=False,
+        )
         assert result["status"] == "pending"
         assert any("payouts not enabled" in i for i in result["issues"])
 
-    def test_activate_stripe_error_with_fallback(self, registry: OperatorRegistry, registered_op: OperatorProfile) -> None:
+    def test_activate_stripe_error_with_fallback(
+        self, registry: OperatorRegistry, registered_op: OperatorProfile
+    ) -> None:
         """When Stripe API errors, falls back to test account."""
         self._prepare_for_activation(registry, registered_op)
 
         class MockStripe:
             stub_mode = False
+
             def get_account(self, acct_id):
                 return {"error": "No such account", "error_type": "InvalidRequestError"}
 
-        result = registry.activate(registered_op.operator_id, stripe_service=MockStripe(), use_test_account_fallback=True)
+        result = registry.activate(
+            registered_op.operator_id,
+            stripe_service=MockStripe(),
+            use_test_account_fallback=True,
+        )
         assert result["status"] == "active"
         assert "stripe_warning" in result
 
@@ -251,6 +278,7 @@ class TestActivate:
 
         class MockStripe:
             stub_mode = False
+
             def get_account(self, acct_id):
                 return {"payouts_enabled": True, "charges_enabled": True}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,9 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"auction/tests/*" = ["S101", "S105", "S106", "E402"]  # allow assert, test passwords, conditional imports
+"auction/tests/*" = ["S101", "S105", "S106", "E402", "S311"]  # allow assert, test passwords, conditional imports, non-crypto random (test fixtures)
+"auction/mock_fleet.py" = ["S311"]  # seeded random for simulated survey data, not crypto
+"auction/operator_registry.py" = ["S311"]  # random operator_id suffix, not crypto
 "auction/api.py" = ["E402"]  # conditional FastAPI import
 "auction/mcp_tools.py" = ["E402", "E501"]  # conditional imports + long docstrings
 "auction/demo.py" = ["E402"]  # imports after dotenv.load_dotenv()


### PR DESCRIPTION
## Summary
Makes all three CI jobs (unit-tests, type-check, lint) green with proper root-cause fixes rather than blanket suppressions.

## Real bugs
- **`engine.py` datetime import**: lines 628-629 and 827 referenced `datetime` without importing it at module scope — would raise `NameError` when the busy-state branch ran. Consolidated imports, removed inline ones, dropped deprecated `_dt.timezone.utc`.

## Test harness
- **`test_fakerover_bid.py`**: imported the fakerover plugin from a sibling `yakrover-8004-mcp` repo that isn't checked out on CI. Replaced with `pytest.skip(..., allow_module_level=True)` when the path is missing. Previously `pytest -x` aborted the whole suite at collection.

## Type annotations
- `deliverable_qa.py` — `type_map` annotated
- `mock_fleet.py` — `readings` typed, avg computations extracted
- `mcp_robot_adapter.py` — `from typing import Any`, annotated several locals
- `mcp_tools.py` — `categories: dict[str, int]`

## Exception handling
Three `try: ... except: pass` sites in `mcp_tools.py` replaced with structured `log.warning/info/debug` calls. Failures surface in Fly logs instead of silent drops.

## Lint cleanup
- Removed redundant `import json as _json` (module already imports `json`)
- Removed unused `import pytest` from `test_delivery_schemas_e2e.py`
- Rewrapped 9 lines >120 chars (method sigs + long f-strings) — no `noqa` added

## Per-file ignores (S311 only)
Added `S311` to `auction/tests/*`, `auction/mock_fleet.py`, `auction/operator_registry.py`. These legitimately use `random` for simulated survey data and operator_id suffixes — not crypto. Targeted per-file scope (same pattern as existing `S101`/`S105` tests exemptions).

## Formatting
Ran `ruff format auction/` — 12 files had accumulated drift. CI's `ruff format --check auction/` now passes.

## Verified locally
- `uv run pytest auction/tests/ -q --ignore=auction/tests/integration` → **306 passed**
- `uv run mypy auction/ --ignore-missing-imports` → **0 errors, 24 files**
- `uv run ruff check auction/` → **all passed**
- `uv run ruff format --check auction/` → **57 files clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)