### PR TITLE
Triage + commit previously-untracked docs; gitignore dead experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ eas_attestation_log.json
 worker/.wrangler/
 .wrangler/
 .notifications/
+
+# Design / research scratch dirs — not part of the shipped repo
+docs/experiments/
+docs/images/

--- a/docs/memo/STYLE_GUIDE.md
+++ b/docs/memo/STYLE_GUIDE.md
@@ -1,0 +1,87 @@
+# Yak Robotics Style Guide (Gwern-adapted)
+
+Adapted from the [Gwern.net Manual of Style](https://gwern.net/style-guide) for a technical robotics marketplace brief. This documents which Gwern patterns apply to our context and which we skip.
+
+## Design Principles Adopted
+
+### Typography
+- **Serif body text**: Source Serif 4 for reading; monospace (JetBrains Mono) reserved for code, commands, and data values only
+- **18px base font size**: larger than typical web, optimized for sustained reading
+- **1.8 line-height** for body, 1.3 for headings
+- **~700px max-width** for body text column (60-75 chars per line, Gwern standard)
+- **Justified text with hyphens**: Gwern uses full justification; we adopt this for the essay feel
+- **Emphasis cycle**: **bold** -> *italics* -> small caps (repeating)
+- **First line smallcaps**: first line of the opening paragraph uses smallcaps (Gwern convention)
+
+### Color Palette
+- Background: `#fffff8` (warm cream, Gwern's signature off-white)
+- Body text: `#000` (true black for max contrast)
+- Headings: `#000` (no colored headings — color is for links and accents only)
+- Links: `#3b7ea1` (Gwern's muted teal-blue)
+- Link hover: underline appears (no underline by default)
+- Muted/secondary: `#555`
+- Borders: `#ddd`
+- Brand accent: `#E8792B` (Yak orange — used only for the header rule and CTAs, never structural)
+- Code background: `#f0f0f0`
+
+### Information Hierarchy (Iceberg Model)
+From Gwern's structure section:
+1. **Abstract** (blockquote at top) — the executive summary becomes a proper abstract
+2. **Margin notes** — brief 1-3 word summaries in the left margin on desktop, inline on mobile
+3. **Body paragraphs** — the main content
+4. **Sidenotes** — evidence, citations, asides float in the right margin (replace our current evidence popovers)
+5. **Collapsible sections** — detailed breakdowns that readers can expand
+6. **Appendices** — reference tables, full lists
+
+### Link Behavior (from HTML section)
+- No underline by default (cleaner reading flow)
+- Underline on hover
+- External links: append `title` attribute with `'Title', Author Year` metadata
+- First use of a term or citation is hyperlinked; subsequent uses are not
+- Links should be to fulltext URLs where possible
+
+### Headings (from Structure section)
+- Mixed title case (not uppercase transforms)
+- h1: large serif, normal weight, bottom rule
+- h2: section headers, <6 words, with thin separator rule
+- h3: subsection, bold
+- Headers should not exceed 6 words to prevent ToC line-wrapping
+
+### Structure Rules
+- Sections should be at least 2 paragraphs long
+- Information density goes left-to-right: section title -> margin note -> paragraph -> sidenote -> collapse -> appendix
+- "See Also" / external links at the end
+- Footnotes <200 words; essays <10,000 words
+
+### HTML Conventions (from HTML section)
+- Use raw `<div>`/`<span>` for control, not framework abstractions
+- Big-endian class naming: `link-live`, `link-icon`, with `-not` suffix for negation
+- `div.abstract` containing a blockquote for the page abstract
+- `div.collapse` with `.abstract-collapse` for expandable sections
+- `div.admonition [tip/note/warning]` for callouts
+- `div.epigraph` for opening quotes
+- Self-documenting: all elements readable as text or with useful `title` attributes
+
+### What We Skip from Gwern
+- Pandoc/Markdown compilation (we write raw HTML)
+- Dropcaps (nice but unnecessary for a brief)
+- Transclusion system (site-specific, not applicable to single-file)
+- Backlinks and similar-links sections
+- Poetry formatting
+- Link archiving and link-rot prevention
+- Inflation adjustment syntax
+- Interwiki shortcuts
+
+## Key Visual Differences from Current Memo
+
+| Current Memo | Gwern-style Version |
+|---|---|
+| JetBrains Mono everywhere | Source Serif 4 body, JetBrains Mono code only |
+| Orange (#E8792B) h2 headings | Black headings, thin rule separators |
+| UPPERCASE section titles | Title case |
+| White background (#fff) | Warm cream (#fffff8) |
+| Evidence popovers (click) | Sidenotes in right margin (always visible on desktop) |
+| Breadcrumb nav bar | Table of contents sidebar or top block |
+| 1100px max-width | ~700px text column with wide margins for sidenotes |
+| 15px font size | 18px font size |
+| Two-column layouts | Single column with margin notes |

--- a/docs/research/SKILL_ARCHITECTURE_PLAN.md
+++ b/docs/research/SKILL_ARCHITECTURE_PLAN.md
@@ -1,0 +1,347 @@
+# Skill Architecture Plan — Yak Robotics Marketplace
+
+**Date:** 2026-04-16
+**Status:** Draft
+**Goal:** Design and build production-quality Claude Code skills for the robot marketplace, targeting registration in the Anthropic official plugin directory (`anthropics/claude-plugins-official`).
+
+---
+
+## 1. Design Frameworks
+
+This plan synthesizes three frameworks:
+
+### A. Springett Hard Worlds (skill-creator-springett)
+
+Core principle: **Build the bump, not the sign.** Constraints should be world physics (enforced by scripts/schemas), not actor guidance (prose instructions Claude might forget).
+
+- **World physics:** Validation, budget ceilings, SLA deadlines, sensor matching — enforced by the MCP server's `auction_validate_task_specs`, not by SKILL.md prose.
+- **Room structure:** The vocabulary of available tools, file locations, and context in scope. The SKILL.md defines what Claude can see and reach.
+- **Actor guidance:** Judgment calls, user interaction patterns, tone. This is what SKILL.md prose is for.
+
+Failure diagnostics (ontological hardness):
+- **Lexical:** Can Claude find the right tool? Are 39 tool names unambiguous?
+- **Interface:** Right tool, wrong arguments? Are schemas clear?
+- **World:** Did the action produce the right state? Is the state inspectable?
+- **Temporal:** Did Claude lose track of what already happened?
+
+### B. Knowledge Objects (thejaymo.net)
+
+Domain knowledge should be structured as reusable YAML artifacts with:
+- Thesis stack (primary/secondary/tertiary claims)
+- Argument maps with evidence and logic paths
+- Provenance chain (author, source, license)
+- Machine-readable salience (models reason over structure, not just text)
+
+Application: Equipment capability profiles, survey methodology standards, and regulatory requirements should be Knowledge Objects in the `references/` directory, not inline prose.
+
+### C. here-now Reference Implementation
+
+The best-in-class skill we've observed. Key patterns to adopt:
+
+| Pattern | here-now | Yak Robotics equivalent |
+|---------|----------|------------------------|
+| **One script does the work** | `scripts/publish.sh` (351 lines) | `scripts/hire-robot.sh` or MCP calls directly |
+| **SKILL.md is the guide, not the engine** | 273 lines of instructions, script does execution | SKILL.md orchestrates MCP tool calls |
+| **References for advanced ops** | `references/REFERENCE.md` (767 lines) | `references/TASK_CATEGORIES.md`, `references/EQUIPMENT_PROFILES.md` |
+| **State management** | `.herenow/state.json` tracks published sites | Auction state lives server-side (SQLite), no local state needed |
+| **Credential handling** | `~/.herenow/credentials` with clear priority chain | MCP bearer token or no auth (public demo) |
+| **Description triggers on natural language** | "publish this", "host this", "deploy this" | "hire a robot", "survey this site", "I need a drone" |
+| **Versioned** | `Skill version: 1.8.3` | Version in SKILL.md frontmatter |
+| **What to tell the user** section | Explicit guidance on what to communicate | Same — what to show after auction completes |
+
+---
+
+## 2. Skill Inventory
+
+### Existing Skills (`.claude/skills/`)
+
+| Skill | Purpose | Status |
+|-------|---------|--------|
+| `rfp-to-robot-spec` | Parse RFP into structured task specs | Functional |
+| `rfp-to-site-recon` | Generate site recon from RFP data | Functional |
+| `bond-verification` | Verify payment bonds against Treasury Circular 570 | Functional |
+| `legal-terms-compare` | Compare survey subcontract terms | Functional |
+
+### New Skills to Build
+
+| Skill | Purpose | Priority | Complexity |
+|-------|---------|----------|------------|
+| `hire-robot` | End-to-end: describe need → post task → review bids → award → execute → verify delivery | **P0** | High |
+| `onboard-operator` | Register operator: profile → equipment → credentials → payment → activation | **P0** | Medium |
+| `demand-signal` | When no robot can fulfill a request, broadcast the unmet demand to an operator-facing feed | **P1** | Medium |
+
+### Why These Three
+
+**`hire-robot`** is the buyer journey. It's what the memo promises: "an AI agent can post a task, receive ranked bids from 100 robots, and settle payment in a single session." This skill turns 39 raw tools into that experience.
+
+**`onboard-operator`** is the supply side. Without operators registering real robots, the marketplace has no supply. This skill guides the 3-step registration (Profile → Equipment → Payment & Bidding) that currently only works through the demo UI.
+
+**`demand-signal`** addresses the cold-start problem. When a buyer requests a capability that no registered robot can fulfill (e.g., "GPR subsurface scan in rural Montana"), the skill should:
+1. Log the unmet request with location, capability requirements, and budget range
+2. Broadcast to an operator-facing feed (MCP resource or API endpoint)
+3. Allow operators to see real demand data and invest in equipment accordingly
+4. Close the loop: when an operator registers a matching robot, notify the original requester
+
+This turns failed auctions into market intelligence — the marketplace equivalent of "customers searched for X but we don't carry it."
+
+---
+
+## 3. Skill Design: `hire-robot`
+
+### SKILL.md Structure (following here-now pattern)
+
+```
+hire-robot/
+  SKILL.md                          # 200-300 lines, orchestration guide
+  references/
+    TASK_CATEGORIES.md              # 18 categories with descriptions
+    EQUIPMENT_PROFILES.md           # Robot types, sensors, capabilities
+    PAYMENT_METHODS.md              # Card, ACH, USDC — what to expect
+  evals/
+    evals.json                      # 3-5 test scenarios
+```
+
+### Frontmatter
+
+```yaml
+---
+name: hire-robot
+description: >
+  Hire a robot for a physical-world task through the Yak Robotics auction
+  marketplace. Use when the user needs a drone survey, LiDAR scan, bridge
+  inspection, GPR subsurface scan, thermal inspection, construction monitoring,
+  or any physical data collection task. Also trigger on "I need a survey",
+  "find me a drone operator", "get a quote for site inspection", "hire a
+  robot", "run an auction", or "post a task".
+---
+```
+
+### Flow (Staged Commitment per Springett)
+
+**Stage 1 — Understand the Need** (no tools called yet)
+- Parse user's natural language request
+- Identify task category, location, budget range, timeline
+- If ambiguous, ask clarifying questions
+- Present the structured task spec for user confirmation before proceeding
+
+**Stage 2 — Post Task & Collect Bids** (tools: `auction_post_task`, `auction_get_bids`)
+- Post the confirmed task spec
+- Wait for bids (SLA-dependent, typically seconds in demo)
+- Present ranked bids with scoring breakdown
+- Recommend the top bid with reasoning
+
+**Stage 3 — Award & Execute** (tools: `auction_award_with_confirmation`, `auction_accept_and_execute`)
+- User confirms the winner
+- Execute the task
+- Monitor execution status
+
+**Stage 4 — Verify & Settle** (tools: `auction_confirm_delivery`, `auction_track_execution`)
+- Receive delivery data
+- Run QA checks
+- Present results to user
+- Trigger settlement
+
+**Stage 5 — No Match Handling** (tools: `auction_get_task_feed` + demand signal)
+- If no robots can fulfill the request, explain why
+- Log the unmet demand (location, capability, budget)
+- Suggest alternative task categories if applicable
+- Inform user that operators will be notified of the demand
+
+### What to Tell the User (per here-now pattern)
+
+- After posting: show task ID, category, budget, number of eligible robots
+- After bids: show top 3 bids with price, SLA, robot name, equipment
+- After award: show winner, agreed price, estimated delivery time
+- After delivery: show QA result, key data points, settlement status
+- On failure: explain what went wrong, what the user can do
+
+---
+
+## 4. Skill Design: `onboard-operator`
+
+### Structure
+
+```
+onboard-operator/
+  SKILL.md
+  references/
+    EQUIPMENT_TYPES.md              # Supported equipment with sensor mappings
+    CREDENTIAL_REQUIREMENTS.md      # FAA Part 107, insurance, PLS
+    STRIPE_CONNECT_GUIDE.md         # Payment onboarding steps
+  evals/
+    evals.json
+```
+
+### Flow
+
+**Stage 1 — Profile** (tool: `auction_onboard_operator_guided`)
+- Company name, contact, location, coverage area
+- Equipment type and model
+- Minimum bid pricing
+
+**Stage 2 — Equipment & Credentials**
+- Add equipment with sensor capabilities
+- Upload FAA Part 107 certification
+- Upload insurance COI
+- Optional: PLS license, SAM registration
+
+**Stage 3 — Payment & Activation** (tools: `auction_activate_operator`, Stripe Connect)
+- Connect Stripe account for payouts
+- Set pricing preferences
+- Activate for bidding
+
+---
+
+## 5. Skill Design: `demand-signal`
+
+### Concept
+
+This is not a user-facing skill in the traditional sense. It's a system behavior triggered when `hire-robot` fails to find a match. The skill:
+
+1. Captures the unmet request as structured data:
+   ```json
+   {
+     "request_id": "...",
+     "task_category": "subsurface_scan",
+     "location": {"lat": 42.29, "lng": -85.59, "description": "Rural Montana"},
+     "capability_requirements": {"sensors_required": ["gpr"]},
+     "budget_range": "$2,000-$5,000",
+     "timestamp": "2026-04-16T...",
+     "status": "unmet"
+   }
+   ```
+
+2. Writes to an operator-facing feed (new MCP tool: `auction_get_demand_signals`)
+
+3. Operators running `onboard-operator` or checking the marketplace see: "3 requests for GPR scanning in Montana in the last 30 days, average budget $3,500. No operators within 200km."
+
+4. When a matching operator registers, the system can notify the original requester (if they opted in).
+
+### Implementation
+
+- New MCP tool: `auction_log_unmet_demand` (called by hire-robot on no-match)
+- New MCP tool: `auction_get_demand_signals` (called by operators or analytics)
+- Storage: SQLite table `unmet_demands` in `SyncTaskStore`
+- Frontend: Add to demo marketplace sidebar or separate dashboard
+
+---
+
+## 6. Tool Vocabulary Audit (Springett Dictionary Discipline)
+
+Current 39 tools — potential dictionary inflation:
+
+| Tool cluster | Tools | Issue? |
+|-------------|-------|--------|
+| Bid flow | `auction_accept_bid`, `auction_accept_and_execute`, `auction_award_with_confirmation` | 3 tools for one concept. Skill should guide which to use when. |
+| Task posting | `auction_post_task`, `auction_validate_task_specs`, `auction_process_rfp` | Clear: validate → post, or rfp → post. OK. |
+| Status | `auction_get_status`, `auction_get_bids`, `auction_review_bids`, `auction_list_tasks`, `auction_get_task_feed` | 5 query tools. Some overlap. |
+| Operator | `auction_onboard_operator`, `auction_onboard_operator_guided`, `auction_register_operator`, `auction_activate_operator`, `auction_update_operator_profile` | 5 tools. `_guided` vs non-guided is the Springett "two verbs for one action" antipattern. |
+
+**Recommendation:** Skills should curate which tools to use. Don't expose all 39 — the skill picks the right 5-8 for its flow. Deferred loading handles the rest.
+
+---
+
+## 7. Plugin Packaging for Anthropic Directory
+
+### Minimum Viable Submission
+
+```
+yakrover/
+  .claude-plugin/
+    plugin.json
+  .mcp.json                         # Points to hosted MCP server
+  skills/
+    hire-robot/
+      SKILL.md
+      references/
+        TASK_CATEGORIES.md
+        EQUIPMENT_PROFILES.md
+    onboard-operator/
+      SKILL.md
+      references/
+        EQUIPMENT_TYPES.md
+        CREDENTIAL_REQUIREMENTS.md
+  README.md
+```
+
+### plugin.json
+
+```json
+{
+  "name": "yakrover",
+  "description": "Robot task auction marketplace. Hire survey robots, post construction tasks, run auctions, and settle payments via MCP. Use when someone needs a drone survey, LiDAR scan, bridge inspection, or any physical data collection.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Yak Robotics Garage",
+    "email": "contact@yakrobot.bid"
+  },
+  "homepage": "https://yakrobot.bid",
+  "repository": "https://github.com/YakRoboticsGarage/yakrover-marketplace"
+}
+```
+
+### .mcp.json
+
+```json
+{
+  "mcpServers": {
+    "yakrover": {
+      "type": "http",
+      "url": "https://yakrover-marketplace.fly.dev/mcp"
+    }
+  }
+}
+```
+
+### Submission Path
+
+1. Build and test `hire-robot` and `onboard-operator` skills
+2. Run evals using skill-creator-springett framework
+3. Package as plugin with `.claude-plugin/plugin.json` + `.mcp.json`
+4. Test install: `claude plugin install yakrover --plugin-dir ./yakrover`
+5. Submit via https://clau.de/plugin-directory-submission
+6. Pass Anthropic quality/security review
+
+### Precedent
+
+Accepted external plugins (Playwright, Supabase, Linear, GitHub) are all:
+- Established companies/projects with public repos
+- Functional MCP servers or tool integrations
+- Clean metadata (plugin.json with name, description, author)
+- Some have Skills, most are MCP-only
+
+YakRover with Skills + MCP would be above-average quality for the directory.
+
+---
+
+## 8. Development Sequence
+
+| Phase | Deliverable | Effort |
+|-------|------------|--------|
+| **1** | `hire-robot/SKILL.md` + references | 1-2 sessions |
+| **2** | `onboard-operator/SKILL.md` + references | 1 session |
+| **3** | Eval suite for both skills (evals.json) | 1 session |
+| **4** | Plugin packaging + local testing | 0.5 session |
+| **5** | `demand-signal` design + new MCP tools | 1-2 sessions |
+| **6** | Submit to Anthropic directory | 0.5 session |
+
+### Key Decisions Needed
+
+1. **Should `hire-robot` handle payment inline or defer?** Currently settlement is functional but the buyer flow through Stripe/USDC is complex. The skill could stop at "task awarded" and link to the demo UI for payment.
+
+2. **Should `demand-signal` be a separate skill or built into `hire-robot`?** Architecturally it's cleaner as a system behavior within `hire-robot` (no-match → log demand). The operator-facing query could be in `onboard-operator`.
+
+3. **Should we submit to Anthropic directory before or after production robots?** The 100-robot test fleet with simulated execution is functional. The skill works. But "simulated execution" may affect Anthropic's quality assessment. Counter-argument: Stripe MCP, GitHub MCP, etc. are all live services — our test fleet is live on Base Sepolia with real ERC-8004 registrations.
+
+---
+
+## References
+
+- [Springett skill-creator](https://github.com/bglek/skill-creator-springett)
+- [Knowledge Objects](https://github.com/tehjaymo/thejaymo.net/tree/main/Objects)
+- [here-now skill](https://here.now/docs) — reference implementation
+- [Anthropic Plugin Directory](https://github.com/anthropics/claude-plugins-official)
+- [Plugin Submission Form](https://clau.de/plugin-directory-submission)
+- [R-053: MCP/Skills/Plugins Research](../research/automated/R-053_mcp_skills_plugins_agent_integration.md)
+- [Claude Code Skills Docs](https://code.claude.com/docs/en/skills)
+- [Claude Code Plugins Docs](https://code.claude.com/docs/en/plugins)

--- a/docs/research/SKILL_ARCHITECTURE_PLAN_v2.md
+++ b/docs/research/SKILL_ARCHITECTURE_PLAN_v2.md
@@ -1,0 +1,289 @@
+# Skill Architecture Plan v2 — Yak Robotics Marketplace
+
+**Date:** 2026-04-16
+**Status:** Draft v2 (post-critique)
+**Goal:** Design the agent integration layer for the robot marketplace, targeting Anthropic official plugin directory.
+
+---
+
+## Multi-Agent Critique Summary
+
+Three perspectives critiqued v1's 3-skill proposal (hire-robot, onboard-operator, demand-signal). Their verdicts diverged sharply, which is the point.
+
+### Buyer Critique
+
+**"hire-robot is three skills pretending to be one."**
+
+The buyer has four distinct intents that map to different sessions and mental states:
+
+1. **Scope** — "I have a problem, help me figure out what I need" (novice buyer, RFP holder)
+2. **Post** — "Here's my spec, put it out for bids" (expert buyer, repeat buyer)
+3. **Award** — "Show me the bids, I want to pick someone" (comes back hours/days later)
+4. **Track** — "What's happening with my job? Is it done? Is it good?" (monitoring + verification)
+
+Plus a fifth for repeat buyers: **Reorder** — "Same as last week, different date."
+
+The demand signal is not a buyer action — it's a byproduct of `scope` finding no match. Capture it where it happens, don't make the buyer do extra work.
+
+**Proposed: 5 buyer-side skills + keep onboard-operator separate = 6 total.**
+
+### Operator Critique
+
+**"Onboarding is dead after day 1. Where's day 2-365?"**
+
+The operator needs:
+- **Onboard** (day 1 wizard) — profile, equipment, credentials, payment
+- **Dashboard** (daily driver) — active bids, completed tasks, earnings, fleet status, demand signals, market rates
+- **Alerts** (proactive) — credential expiry, maintenance intervals, demand spikes, bid outcomes, payouts
+
+Demand signals are not a standalone skill — they're a data layer consumed by the operator dashboard ("show me unmet demand in my area" is a dashboard query, not a separate workflow).
+
+**Proposed: 3 operator-side skills + buyer skills = 8-9 total.**
+
+### Platform/Technical Critique
+
+**"Do not build skills. Build better tools."**
+
+The contrarian case:
+- Every accepted plugin in Anthropic's directory (Stripe, GitHub, Playwright) is **MCP-only, zero skills**. Skills are not required for acceptance.
+- With 39 tools, a skill becomes a brittle orchestration layer that drifts as tools change. The model is better at ad-hoc tool composition than following a rigid script.
+- Skills are Claude Code-specific. MCP tools work everywhere (Cursor, ChatGPT, OpenAI agents). Every hour on skills benefits one client. Every hour on tool descriptions benefits all clients.
+- Skills have a nonzero context floor cost (~500-800 tokens each, loaded every conversation). Tools deferred via ToolSearch cost near-zero until invoked.
+- Tool responses can embed orchestration hints ("No robots found. Use `log_unmet_demand` to notify operators of market gaps.") — this is runtime guidance available to every MCP client, not a stale prompt in one client.
+
+**Proposed: 0 skills. Invest in tool descriptions, tool response messages, and a `marketplace_help` tool.**
+
+---
+
+## Synthesis: Where the Critiques Agree
+
+Despite different conclusions (6 skills / 9 skills / 0 skills), all three agree on:
+
+1. **Demand signal is a data layer, not a skill.** It's a byproduct of failed searches, consumed by operators. Build the MCP tools (`log_unmet_demand`, `get_demand_signals`), surface them in tool responses, don't create a skill for it.
+
+2. **The original 3-skill split was wrong.** It mapped to internal marketplace concepts (buy/sell/signal), not user intents.
+
+3. **Tool quality is the highest-leverage investment.** Whether you build skills or not, the 39 MCP tools need better descriptions, clearer schemas, and orchestration hints in their responses.
+
+4. **Onboarding is architecturally different from daily use.** Even the 0-skills advocate would benefit from this distinction at the MCP tool level.
+
+---
+
+## Revised Architecture: Tools-First, Skills-Light
+
+### Layer 1: MCP Tools (Universal, All Clients)
+
+**This is the primary investment.** Every MCP client (Claude, Cursor, ChatGPT, OpenAI agents) benefits.
+
+#### Tool Description Quality Standard
+
+Every tool gets a 2-3 sentence description following Springett's dictionary discipline:
+- **What it does** (one sentence)
+- **When to use it** (one sentence)
+- **What to call next** (one sentence, optional)
+
+Example:
+```
+auction_post_task:
+  "Post a structured task to the marketplace for robot operators to bid on.
+   Use after the buyer has confirmed a task specification with category,
+   budget, location, and capability requirements. After posting, use
+   auction_get_bids to retrieve ranked bids."
+```
+
+#### Tool Response Orchestration
+
+When a tool returns results, embed next-step guidance in the response:
+
+```json
+{
+  "state": "bidding",
+  "bid_count": 5,
+  "recommended_winner": "robot_042",
+  "_next_steps": [
+    "Use auction_review_bids for detailed comparison",
+    "Use auction_award_with_confirmation to select a winner"
+  ]
+}
+```
+
+When a search fails:
+```json
+{
+  "state": "no_match",
+  "reason": "No robots with GPR capability within 200km of specified location",
+  "_next_steps": [
+    "Use auction_log_unmet_demand to notify operators of this gap",
+    "Try broadening the search radius or relaxing sensor requirements"
+  ]
+}
+```
+
+This is the Springett principle: world physics, not actor guidance. The orchestration knowledge lives in the tool responses where it is contextual, runtime, and universal.
+
+#### New MCP Tools
+
+| Tool | Purpose | Called by |
+|------|---------|----------|
+| `auction_log_unmet_demand` | Log a failed search as market signal | Any client, on no-match |
+| `auction_get_demand_signals` | Query unmet demand by region/capability | Operators checking market |
+| `auction_marketplace_help` | Return structured guide of all capabilities | Any client, on first interaction |
+| `auction_my_tasks` | Buyer: list my posted/active/completed tasks | Buyer dashboard |
+| `auction_my_bids` | Operator: list my active/won/lost bids | Operator dashboard |
+| `auction_my_earnings` | Operator: earnings summary by period | Operator dashboard |
+| `auction_market_rates` | Anonymized aggregate pricing by task type and region | Operator pricing |
+
+#### Tool Vocabulary Audit
+
+Current 39 tools have dictionary inflation in three areas:
+
+| Cluster | Current tools | Recommendation |
+|---------|--------------|----------------|
+| Bid acceptance | `accept_bid`, `accept_and_execute`, `award_with_confirmation` | Keep all three — they serve genuinely different workflows (auto-accept, immediate dispatch, confirmation gate). But descriptions must clearly differentiate when to use each. |
+| Operator onboarding | `onboard_operator`, `onboard_operator_guided`, `register_operator` | Consolidate to 2: `register_operator` (programmatic) and `onboard_operator_guided` (interactive). Drop `onboard_operator` — it's the same as register. |
+| Status queries | `get_status`, `get_bids`, `review_bids`, `list_tasks`, `get_task_feed` | Keep all — different scopes (single task vs all tasks vs feed). Descriptions must clarify. |
+
+### Layer 2: Plugin Packaging (Anthropic Directory)
+
+Minimum viable plugin for directory submission:
+
+```
+yakrover/
+  .claude-plugin/
+    plugin.json
+  .mcp.json
+  README.md
+```
+
+That's it. No skills. This matches the pattern of every accepted external plugin (Stripe, GitHub, Playwright, Linear, Supabase).
+
+**plugin.json:**
+```json
+{
+  "name": "yakrover",
+  "description": "Robot task auction marketplace. Post construction survey tasks, receive bids from certified robot operators, and settle payments. Supports 18 task categories including aerial LiDAR, GPR subsurface scanning, bridge inspection, and thermal imaging. 100+ robots on testnet, 1 physical robot on mainnet.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Yak Robotics Garage",
+    "email": "contact@yakrobot.bid"
+  },
+  "homepage": "https://yakrobot.bid",
+  "repository": "https://github.com/YakRoboticsGarage/yakrover-marketplace"
+}
+```
+
+**.mcp.json:**
+```json
+{
+  "mcpServers": {
+    "yakrover": {
+      "type": "http",
+      "url": "https://yakrover-marketplace.fly.dev/mcp"
+    }
+  }
+}
+```
+
+### Layer 3: Skills (Claude Code-Specific, Optional)
+
+If skills are built at all, they should be **value-adds on top of already-functional tools**, not the primary orchestration layer. The model should be able to run the full buyer and operator flows using just the MCP tools. Skills add guided workflows for users who want hand-holding.
+
+**If we build skills, build exactly two:**
+
+#### `yak` (single buyer-facing skill)
+
+Not `hire-robot`, not 5 separate buyer skills. One skill with a broad trigger:
+
+```yaml
+---
+name: yak
+description: >
+  Robot task auction marketplace. Use when someone needs a drone survey,
+  LiDAR scan, bridge inspection, GPR subsurface scan, thermal inspection,
+  construction monitoring, or any physical data collection. Also trigger on
+  "hire a robot", "find a drone operator", "I need a survey", "post a task",
+  "check my bids", "what's the status of my job", or "reorder last survey".
+---
+```
+
+The body handles branching internally based on user intent:
+- "I need a survey" → scope and post flow
+- "Show me my bids" → status/award flow
+- "Same as last week" → reorder flow
+- "What can you do?" → calls `auction_marketplace_help`
+
+This avoids trigger competition between multiple skills and keeps the context floor to one skill's cost (~500-800 tokens).
+
+#### `yak-operator` (single operator-facing skill)
+
+```yaml
+---
+name: yak-operator
+description: >
+  Register and manage a robot operator account on the Yak Robotics
+  marketplace. Use when someone wants to register a drone, list robots for
+  hire, check their bids and earnings, update equipment, or see what tasks
+  buyers are requesting in their area.
+---
+```
+
+Handles onboarding (day 1) and daily operations (day 2+) with internal branching. New operator → guided registration. Returning operator → dashboard view.
+
+### Layer 4: Knowledge Objects (References)
+
+Domain knowledge stored as structured YAML in `references/` directories, following the thejaymo.net Knowledge Object pattern:
+
+- `TASK_CATEGORIES.yaml.md` — 18 categories with required sensors, deliverable formats, QA criteria
+- `EQUIPMENT_PROFILES.yaml.md` — Robot types, sensor capabilities, coverage specs
+- `REGULATORY_REQUIREMENTS.yaml.md` — FAA Part 107, state PLS rules, insurance minimums
+- `SURVEY_STANDARDS.yaml.md` — ASPRS accuracy classes, USGS density requirements, CRS codes
+
+These are loaded by skills when needed (not always in context) and are also useful as MCP resources.
+
+---
+
+## Development Sequence (Revised)
+
+| Phase | Deliverable | Effort | Impact |
+|-------|------------|--------|--------|
+| **1** | Tool description audit — rewrite all 39 tool descriptions to quality standard | 1 session | High (universal) |
+| **2** | Tool response orchestration — add `_next_steps` to all tool responses | 1-2 sessions | High (universal) |
+| **3** | New MCP tools: `log_unmet_demand`, `get_demand_signals`, `marketplace_help`, `my_tasks`, `my_bids`, `my_earnings`, `market_rates` | 2-3 sessions | High |
+| **4** | Plugin packaging: plugin.json + .mcp.json + README | 0.5 session | Medium (directory submission) |
+| **5** | Submit to Anthropic directory (MCP-only, no skills) | 0.5 session | High |
+| **6** | Optional: `yak` + `yak-operator` skills | 1-2 sessions | Medium (Claude Code only) |
+| **7** | Optional: Knowledge Object references | 1 session | Low-Medium |
+| **8** | Eval suite (if skills built) | 1 session | Medium |
+
+Note the inversion from v1: tools first (phases 1-3), directory submission early (phase 5), skills last and optional (phase 6). This is the key architectural decision.
+
+---
+
+## Key Decisions
+
+### Decided
+
+1. **Demand signal is a data layer, not a skill.** Build `log_unmet_demand` and `get_demand_signals` as MCP tools. Surface them in tool responses on no-match.
+
+2. **Tool quality is the primary investment.** Rewrite descriptions, add response orchestration hints. This benefits all MCP clients.
+
+3. **Plugin submission is MCP-only.** Match the pattern of accepted plugins. No skills required for directory acceptance.
+
+### Open
+
+1. **Should we build the two optional skills?** Arguments for: better Claude Code UX, guided flows for non-technical buyers. Arguments against: maintenance burden, Claude Code-only benefit, tools should be self-sufficient.
+
+2. **Should `_next_steps` be a formal convention or ad-hoc?** Could define it as a standard field in all auction engine responses. Or keep it informal in response text.
+
+3. **Should Knowledge Object references live in the plugin or in the MCP server as resources?** MCP supports resources natively. A `resources/task-categories` URI that returns structured YAML would be universal. Plugin references are Claude Code-only.
+
+---
+
+## References
+
+- [Springett skill-creator](https://github.com/bglek/skill-creator-springett) — Hard Worlds framework
+- [Knowledge Objects](https://github.com/tehjaymo/thejaymo.net/tree/main/Objects) — YAML ontology pattern
+- [here-now skill](https://here.now/docs) — Reference implementation
+- [Anthropic Plugin Directory](https://github.com/anthropics/claude-plugins-official) — Submission target
+- [R-053: MCP/Skills/Plugins Research](../research/automated/R-053_mcp_skills_plugins_agent_integration.md)
+- [v1 Architecture Plan](./SKILL_ARCHITECTURE_PLAN.md) — Superseded by this document

--- a/docs/research/automated/R-053_mcp_skills_plugins_agent_integration.md
+++ b/docs/research/automated/R-053_mcp_skills_plugins_agent_integration.md
@@ -1,0 +1,335 @@
+# R-053: MCP, Skills, and Plugins — Agent Integration Research
+
+**Date:** 2026-04-16
+**Status:** Complete
+**Source:** Claude Code documentation, MCP specification, industry analysis
+
+---
+
+## 1. MCP Architecture
+
+### Protocol Foundation
+
+MCP (Model Context Protocol) is an open protocol using **JSON-RPC 2.0** messages for communication between three actors:
+
+- **Hosts**: LLM applications that initiate connections (e.g., Claude Code, Cursor, Claude Desktop)
+- **Clients**: Connectors within the host that manage individual server connections
+- **Servers**: Services that provide context and capabilities
+
+Created by David Soria Parra and Justin Spahr-Summers at Anthropic, inspired by the Language Server Protocol (LSP). Current spec version: **2025-03-26**.
+
+Spec: https://modelcontextprotocol.io/specification/2025-03-26
+
+### Transport Layers
+
+**stdio** — Client launches the MCP server as a subprocess. Messages are newline-delimited JSON-RPC over stdin/stdout. Server MAY write logs to stderr. Simplest transport, recommended for local integrations.
+
+**Streamable HTTP** (replaces deprecated HTTP+SSE from 2024-11-05) — Server operates as an independent process with a single HTTP endpoint (e.g., `https://example.com/mcp`). Clients POST JSON-RPC messages; servers respond with either `application/json` or `text/event-stream` (SSE) for streaming. Supports session management via `Mcp-Session-Id` headers, resumability via `Last-Event-ID`, and multiple simultaneous connections. Servers MUST validate Origin headers to prevent DNS rebinding attacks.
+
+**Custom transports** — Any bidirectional channel is allowed, provided it preserves JSON-RPC message format and lifecycle requirements.
+
+Spec: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+
+### Connection Lifecycle
+
+1. **Initialization**: Client sends `initialize` request with protocol version, capabilities, and client info. Server responds with its capabilities and protocol version. Client sends `initialized` notification.
+2. **Capability Negotiation**: Server declares support for `tools`, `resources`, `prompts`, `logging`, `completions`. Client declares `roots` and `sampling`.
+3. **Operation**: Normal JSON-RPC message exchange respecting negotiated capabilities.
+4. **Shutdown**: For stdio, close stdin then SIGTERM then SIGKILL. For HTTP, close connections and optionally DELETE the session endpoint.
+
+Spec: https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle
+
+### Server Primitives
+
+**Tools** (model-controlled): Functions the AI model can invoke. Discovered via `tools/list`, invoked via `tools/call`. Each tool has a `name`, `description`, JSON Schema `inputSchema`, and optional `annotations`. Results contain content arrays (text, image, audio, embedded resources) with an `isError` flag.
+
+**Resources** (application-driven): Data/context identified by URIs (file://, https://, git://, custom). Discovered via `resources/list`, read via `resources/read`. Supports templates (RFC 6570 URI templates), subscriptions for change notifications, and pagination.
+
+**Prompts**: Templated messages and workflows for users. Discovered via `prompts/list`.
+
+**Sampling** (client feature): Allows servers to request LLM completions from the client, enabling recursive agent behaviors.
+
+Tool spec: https://modelcontextprotocol.io/specification/2025-03-26/server/tools
+Resource spec: https://modelcontextprotocol.io/specification/2025-03-26/server/resources
+
+---
+
+## 2. MCP in Claude Code
+
+### Configuration Methods
+
+**CLI wizard**:
+```bash
+claude mcp add --transport http <name> <url>
+claude mcp add --transport stdio --env KEY=VALUE <name> -- <command> [args...]
+claude mcp add --transport sse <name> <url>              # deprecated
+```
+
+**Direct JSON** (via `claude mcp add-json`):
+```bash
+claude mcp add-json <name> '{"type":"http","url":"https://..."}'
+```
+
+**Manual `.mcp.json` files** at various scope levels.
+
+### Scope Levels
+
+| Scope | File Location | Shared with team? |
+|-------|--------------|-------------------|
+| User | `~/.claude/.mcp.json` | No |
+| Project | `.mcp.json` in project root | Yes (commit to git) |
+| Local | `.mcp.local.json` in project root | No (gitignored) |
+
+Plugins can also bundle `.mcp.json` at the plugin root.
+
+### Authentication Patterns
+
+- **Bearer tokens / API keys**: `--header "Authorization: Bearer <token>"` or `--env API_KEY=value`
+- **OAuth**: Claude Code supports OAuth flows for remote HTTP servers (used by Stripe, GitHub, etc.)
+- **Environment variables**: Passed to stdio servers via `--env` flag
+
+### Deferred Tool Loading (ToolSearch)
+
+Launched January 14, 2026. Critical optimization:
+
+- At session start, only tool **names** are loaded into context (not full schemas).
+- When Claude needs a tool, it uses the `ToolSearch` meta-tool to search by regex or BM25 semantic matching.
+- The API returns 3-5 relevant `tool_reference` blocks that expand into full definitions inline.
+- **Impact**: Reduces context from ~77K tokens (50+ MCP tools, traditional) to ~8.7K tokens — a 95% reduction. The ToolSearch tool itself adds only ~500 tokens.
+- As of v2.1.69, even built-in tools (Bash, Read, Edit, etc.) are deferred behind ToolSearch.
+
+References:
+- https://code.claude.com/docs/en/mcp
+- https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool
+
+---
+
+## 3. Skills in Claude Code
+
+### What is a Skill?
+
+A Skill is a reusable set of instructions packaged as a `SKILL.md` file. Skills extend Claude's behavior without giving it new tools — they shape its approach. The body loads only when invoked, so long reference material costs almost nothing until needed.
+
+Skills follow the open [Agent Skills](https://agentskills.io) standard.
+
+### SKILL.md Structure
+
+```yaml
+---
+name: my-skill
+description: What this skill does
+when_to_use: additional trigger phrases
+disable-model-invocation: false
+user-invocable: true
+allowed-tools: Bash(git *) Read
+context: fork
+agent: Explore
+model: opus
+effort: high
+paths: "*.py,src/**"
+---
+
+Markdown instructions here...
+$ARGUMENTS placeholder for user input
+!`shell command` for dynamic context injection
+```
+
+### Discovery and Invocation
+
+| Location | Path | Scope |
+|----------|------|-------|
+| Enterprise | Managed settings | All org users |
+| Personal | `~/.claude/skills/<name>/SKILL.md` | All your projects |
+| Project | `.claude/skills/<name>/SKILL.md` | This project only |
+| Plugin | `<plugin>/skills/<name>/SKILL.md` | Where plugin is enabled |
+
+**Auto-invocation**: Skill descriptions are always in context (~1,536 char cap each). Claude matches them against conversation context and loads the full content when relevant.
+
+**Manual invocation**: User types `/skill-name [arguments]`.
+
+### Skills vs MCP Tools
+
+| Dimension | Skills | MCP Tools |
+|-----------|--------|-----------|
+| Purpose | Shape Claude's behavior/approach | Give Claude new capabilities |
+| Mechanism | Prompt injection (instructions) | External function calls |
+| Discovery | Description matching | ToolSearch (deferred schemas) |
+| Execution | Inline or forked subagent | JSON-RPC to MCP server |
+| Can call MCP tools? | Yes | N/A |
+| Can MCP trigger skills? | No | N/A |
+
+Docs: https://code.claude.com/docs/en/skills
+
+---
+
+## 4. Plugins in Claude Code
+
+### What is a Plugin?
+
+A Plugin is a distributable package that bundles skills, agents, hooks, MCP servers, LSP servers, bin executables, and settings into a single unit with a namespace. Plugin skills use `plugin-name:skill-name` format to prevent conflicts.
+
+### Directory Structure
+
+```
+my-plugin/
+  .claude-plugin/
+    plugin.json          # manifest (required)
+  skills/                # skill directories
+  commands/              # flat .md skill files
+  agents/                # custom agent definitions
+  hooks/
+    hooks.json           # event handlers
+  .mcp.json              # MCP server configs
+  .lsp.json              # LSP server configs
+  bin/                   # executables added to PATH
+  settings.json          # default settings
+```
+
+### plugin.json Schema
+
+```json
+{
+  "name": "my-plugin",
+  "description": "What this plugin does",
+  "version": "1.0.0",
+  "author": { "name": "Your Name" },
+  "homepage": "https://...",
+  "repository": "https://..."
+}
+```
+
+### Plugin Marketplace
+
+A marketplace is a Git repository with `.claude-plugin/marketplace.json`. Plugins can be sourced from: relative paths, GitHub repos, git URLs, git subdirectories (sparse clone for monorepos), npm packages.
+
+**Install flow**:
+```bash
+# Add marketplace
+claude plugin marketplace add owner/repo
+
+# Install plugin
+claude plugin install my-plugin@marketplace-name
+
+# Update
+claude plugin marketplace update
+```
+
+**Official marketplace**: `anthropics/claude-plugins-official` — 100+ plugins as of early 2026.
+
+Docs:
+- https://code.claude.com/docs/en/plugins
+- https://code.claude.com/docs/en/plugin-marketplaces
+
+### Plugins vs Skills vs MCP
+
+| Feature | MCP Server | Skill | Plugin |
+|---------|-----------|-------|--------|
+| Gives Claude new tools | Yes | No (shapes behavior) | Bundles all |
+| External process | Yes | No | May include MCP servers |
+| Distributable | As npm/docker/URL | Via git commit | Full marketplace system |
+| Namespace | `mcp__server__tool` | `/skill-name` | `/plugin:skill` |
+| Install command | `claude mcp add` | Copy SKILL.md | `/plugin install` |
+
+---
+
+## 5. Integration Patterns for Yak Robotics
+
+### How Major Projects Distribute MCP
+
+**Stripe** (https://docs.stripe.com/mcp):
+- Remote HTTP server at `https://mcp.stripe.com` with OAuth
+- Also available as local `npx -y @stripe/mcp` with API key
+- Install: `claude mcp add --transport http stripe https://mcp.stripe.com/`
+
+**GitHub** (https://github.com/github/github-mcp-server):
+- Remote HTTP at `https://api.githubcopilot.com/mcp/` with OAuth
+- Local Docker image `ghcr.io/github/github-mcp-server` with PAT via stdio
+- Configurable toolsets (repos, issues, PRs, actions, etc.)
+
+**Common pattern**: Dual offering — remote HTTP (primary, OAuth) + local stdio (fallback, API key).
+
+### Hosted vs Local MCP Tradeoffs
+
+| Factor | Hosted (HTTP) | Local (stdio) |
+|--------|--------------|---------------|
+| Setup complexity | One-line URL | Requires npx/docker |
+| Multi-user | Yes | Per-machine |
+| Authentication | OAuth/API key | Env vars |
+| Latency | Network hop | Local, faster |
+| Mobile/web clients | Works everywhere | Desktop only |
+| Maintenance | Server manages uptime | User manages process |
+| State management | Server-side sessions | Per-process |
+
+**For a marketplace with paying customers**: Remote HTTP is strongly recommended.
+
+### Recommended Architecture for Yak Robotics
+
+1. **Primary distribution**: Remote HTTP MCP server (`https://yakrover-marketplace.fly.dev/mcp`) with API key auth. Works with Claude, Cursor, ChatGPT, OpenAI agents, LangChain — any MCP client.
+
+2. **Enhanced Claude Code experience**: Plugin that bundles MCP server config + Skills (guided workflows like `/yak:run-auction`, `/yak:process-rfp`, `/yak:onboard-operator`) + hooks for validation.
+
+3. **Deferred loading handles scale**: With ToolSearch, 39 tools add minimal context overhead (~500 tokens for ToolSearch + tool names, vs ~30K+ if all schemas loaded).
+
+4. **Cross-platform**: Same MCP server works everywhere. Skills and Plugins are Claude Code-specific value-adds.
+
+### Ideal Onboarding Flow
+
+**Simplest (any MCP client)**:
+```bash
+claude mcp add --transport http yakrover https://yakrover-marketplace.fly.dev/mcp
+```
+
+**Full experience (Claude Code)**:
+```bash
+claude plugin marketplace add YakRoboticsGarage/yakrover-marketplace
+claude plugin install yakrover
+```
+
+---
+
+## 6. Cross-Agent Compatibility
+
+### MCP Adoption (April 2026)
+
+- **97 million** monthly SDK downloads across TypeScript, Python, Java, Kotlin, C#, Swift
+- **500+** public MCP servers indexed in community directories
+- **4,000+** servers listed in largest registries
+
+### Client Support
+
+| Client | MCP Support | Transport |
+|--------|------------|-----------|
+| Claude Code | Full | stdio, HTTP, SSE |
+| Claude Desktop | Full | stdio, HTTP, SSE |
+| Cursor | Full | stdio, HTTP |
+| Windsurf | Full | stdio, HTTP |
+| VS Code (Copilot) | Full | stdio, HTTP |
+| ChatGPT | Full | HTTP (OAuth required) |
+| OpenAI Agents SDK | Full | stdio, HTTP, SSE |
+| OpenAI Codex | Full | MCP shortcuts |
+| LangChain | Via adapter | All transports |
+| CrewAI | Via adapter | stdio |
+
+### MCP vs Function Calling vs OpenAPI
+
+- **MCP**: Write the tool once, works in any MCP client. Standardized discovery, stateful sessions, streaming. Best for: portable integrations, multi-tool servers.
+- **Function calling** (OpenAI/Anthropic native): Tightly coupled to a single API call. Every schema sent in every request. Best for: simple, single-provider apps.
+- **OpenAPI/REST**: HTTP endpoints without AI-specific semantics. Requires custom wrapping per agent framework.
+
+---
+
+## Key References
+
+- [MCP Specification](https://modelcontextprotocol.io/specification/2025-03-26)
+- [MCP Transports](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports)
+- [MCP Lifecycle](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle)
+- [Claude Code MCP Docs](https://code.claude.com/docs/en/mcp)
+- [Claude Code Skills Docs](https://code.claude.com/docs/en/skills)
+- [Claude Code Plugins Docs](https://code.claude.com/docs/en/plugins)
+- [Claude Code Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)
+- [Tool Search Tool API Docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)
+- [Stripe MCP](https://docs.stripe.com/mcp)
+- [GitHub MCP Server](https://github.com/github/github-mcp-server)
+- [OpenAI Agents SDK MCP](https://openai.github.io/openai-agents-python/mcp/)
+- [MCP Authorization Tutorial](https://modelcontextprotocol.io/docs/tutorials/security/authorization)
+- [MCP vs Function Calling](https://www.descope.com/blog/post/mcp-vs-function-calling)


### PR DESCRIPTION
## Summary
Five items had been untracked in the working tree for days (visible in `gh pr create --warning: N uncommitted changes` output on the last several PRs). Audited each and placed them in their correct home or removed them.

## Committed

| File | Home | Rationale |
|---|---|---|
| `docs/research/SKILL_ARCHITECTURE_PLAN.md` (moved from `architecture/`) | research | Skill deployment isn't on the active roadmap — this is exploration, not a plan-in-flight. `architecture/` implies active design. |
| `docs/research/SKILL_ARCHITECTURE_PLAN_v2.md` (moved from `architecture/`) | research | Same, v2 with multi-agent critique. |
| `docs/research/automated/R-053_mcp_skills_plugins_agent_integration.md` | research (already correct) | Complete research doc; needed `git add`. |
| `docs/memo/STYLE_GUIDE.md` (rescued from `experiments/gwern-style/`) | next to the pages that use it | Codified Gwern-adapted design system for the live `memo/` and `memo-space/` pages. Not experimental. |

## Deleted + gitignored

| Path | Why | Size |
|---|---|---|
| `docs/experiments/gwern-style/` | Pre-production HTML prototypes (memo-plex, memo-v2, font-test) superseded by live `docs/memo/` and `docs/memo-space/`. Plus a reference PDF. | ~6 MB |
| `docs/images/{headerimagetest2,opengraphimagetest1,opengraphimagetest2}.png` | Zero references in the repo. Production og:image + header assets live at `docs/memo/og-image.png` and `docs/memo/header-bg.png` and are already tracked. These test renders never made it into any running site. | ~16 MB |

Both dirs added to `.gitignore` so future scratch doesn't pollute `git status`.

## No behavior change
Purely docs/infra. Marketplace code untouched; CI shouldn't redeploy the Fly app (paths-ignore filter excludes `docs/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)