### PR TITLE
Fix MCPRobotAdapter: recover from remote MCP session invalidation

### DIFF
--- a/auction/mcp_robot_adapter.py
+++ b/auction/mcp_robot_adapter.py
@@ -157,8 +157,33 @@ class MCPRobotAdapter:
             h["Authorization"] = f"Bearer {self.bearer_token}"
         return h
 
+    async def _mcp_init_session(self, client: httpx.AsyncClient) -> None:
+        """Open a fresh MCP session against the remote server. Sets _session_id."""
+        init_resp = await client.post(
+            self.mcp_endpoint,
+            headers=self._mcp_headers(),
+            json={
+                "jsonrpc": "2.0",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "marketplace", "version": "1.0"},
+                },
+                "id": 0,
+            },
+        )
+        sid = init_resp.headers.get("mcp-session-id")
+        if sid:
+            self._session_id = sid
+
     async def _mcp_call(self, method: str, params: dict, call_id: int = 1) -> dict | None:
-        """Make an MCP JSON-RPC call and return the result."""
+        """Make an MCP JSON-RPC call and return the result.
+
+        If the remote MCP server restarts, our cached _session_id becomes stale
+        and the server returns 404 "session not found". Detect that (and 400
+        "missing session") and retry once with a fresh session before giving up.
+        """
         payload = {
             "jsonrpc": "2.0",
             "method": method,
@@ -167,32 +192,36 @@ class MCPRobotAdapter:
         }
 
         async with httpx.AsyncClient(timeout=30.0) as client:
-            # Initialize session if needed
             if not self._session_id:
-                init_resp = await client.post(
-                    self.mcp_endpoint,
-                    headers=self._mcp_headers(),
-                    json={
-                        "jsonrpc": "2.0",
-                        "method": "initialize",
-                        "params": {
-                            "protocolVersion": "2025-03-26",
-                            "capabilities": {},
-                            "clientInfo": {"name": "marketplace", "version": "1.0"},
-                        },
-                        "id": 0,
-                    },
-                )
-                # Extract session ID from response header
-                sid = init_resp.headers.get("mcp-session-id")
-                if sid:
-                    self._session_id = sid
+                await self._mcp_init_session(client)
 
             resp = await client.post(
                 self.mcp_endpoint,
                 headers=self._mcp_headers(),
                 json=payload,
             )
+
+            # Session expired (server restart) or missing — re-init and retry once.
+            if resp.status_code in (400, 404) and self._session_id is not None:
+                log.info(
+                    "MCP %s returned %d — session likely stale after remote restart; re-initializing and retrying",
+                    self.robot_id,
+                    resp.status_code,
+                )
+                self._session_id = None
+                await self._mcp_init_session(client)
+                resp = await client.post(
+                    self.mcp_endpoint,
+                    headers=self._mcp_headers(),
+                    json=payload,
+                )
+
+            if resp.status_code >= 400:
+                log.warning(
+                    "MCP call %s to %s failed after retry: HTTP %d",
+                    method, self.robot_id, resp.status_code,
+                )
+                return None
 
         # Parse SSE response — look for data: lines
         for line in resp.text.split("\n"):


### PR DESCRIPTION
## Summary
`MCPRobotAdapter._mcp_call` cached the MCP session id on the adapter instance and never reset it when the remote server invalidated it. When an operator's MCP server restarted (OOM, redeploy, crash loop), every subsequent `robot_submit_bid` silently returned None and bids never arrived.

**Real incident today:** npc-robot-mcp Fly app OOM-restarted; every bid call since returned 404 from the remote server; `auction_get_bids` reported 0 bids despite NPC ROBOT being in `eligible_robot_ids`.

## Fix
- Extract session init into `_mcp_init_session`
- On 400/404 with a cached session id, clear it, re-init, retry the call once
- Check `resp.status_code` before SSE parsing; log + bail if still 4xx after retry

## Tests
- 306 unit tests unchanged
- Ruff + mypy clean on the touched file

## Runtime impact
After this merges, any live-production operator whose MCP endpoint restarts will continue bidding automatically. Previously they required a marketplace restart to recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)