### PR TITLE
Release busy state on completion + add auction_get_robot_status tool

### DIFF
--- a/auction/engine.py
+++ b/auction/engine.py
@@ -830,7 +830,7 @@ class AuctionEngine:
             "site_survey": 60 * 60,
             "environmental_survey": 45 * 60,
         }
-        busy_seconds = duration_map.get(task_cat, 30 * 60)  # default 30 min
+        busy_seconds = duration_map.get(task_cat, 30 * 60)  # default 30 min (upper bound)
         robot._busy_until = datetime.now(UTC) + timedelta(seconds=busy_seconds)
         log("BUSY", f"{robot_id} busy for {busy_seconds}s (task: {task_cat})")
 
@@ -856,6 +856,61 @@ class AuctionEngine:
             "payment": "on_delivery",
             "next_action": "Call auction_execute(request_id) to dispatch the task to the winning robot.",
             "next_tool": "auction_execute",
+        }
+
+    # ------------------------------------------------------------------
+    # Busy state (release on completion/abort) + robot status snapshot
+    # ------------------------------------------------------------------
+
+    def _clear_busy(self, robot_id: str) -> None:
+        """Release a robot's busy reservation. Called when execution ends."""
+        robot = self._robots_by_id.get(robot_id)
+        if robot is None:
+            return
+        prev = getattr(robot, "_busy_until", None)
+        if prev is None:
+            return
+        robot._busy_until = None
+        log("BUSY", f"{robot_id} released (previously held until {prev.isoformat()})")
+
+    def get_robot_status(self, robot_id: str) -> dict:
+        """Return a snapshot of a robot's current fleet-level state."""
+        robot = self._robots_by_id.get(robot_id)
+        if robot is None:
+            return {"robot_id": robot_id, "found": False}
+
+        now = datetime.now(UTC)
+        busy_until = getattr(robot, "_busy_until", None)
+        if busy_until is not None and busy_until > now:
+            busy = True
+            busy_remaining_s = int((busy_until - now).total_seconds())
+        else:
+            busy = False
+            busy_remaining_s = 0
+
+        won_tasks = [
+            r for r in self._tasks.values() if r.winning_bid is not None and r.winning_bid.robot_id == robot_id
+        ]
+        active_tasks = [r for r in won_tasks if r.state not in (TaskState.SETTLED, TaskState.WITHDRAWN)]
+        completed_tasks = [r for r in won_tasks if r.state == TaskState.SETTLED]
+
+        return {
+            "robot_id": robot_id,
+            "found": True,
+            "busy": busy,
+            "busy_until": busy_until.isoformat() if busy_until else None,
+            "busy_remaining_seconds": busy_remaining_s,
+            "total_tasks_won": len(won_tasks),
+            "active_tasks": len(active_tasks),
+            "completed_tasks": len(completed_tasks),
+            "accepted_task_types": list(getattr(robot, "_accepted_task_types", []) or []),
+            "min_bid_cents": getattr(robot, "_min_bid_cents", None),
+            "service_radius_km": getattr(robot, "_service_radius_km", None),
+            "mcp_endpoint": getattr(robot, "mcp_endpoint", None),
+            "location": {
+                "latitude": getattr(robot, "_latitude", None),
+                "longitude": getattr(robot, "_longitude", None),
+            },
         }
 
     # ------------------------------------------------------------------
@@ -897,6 +952,8 @@ class AuctionEngine:
 
             # IN_PROGRESS -> ABANDONED
             self._transition(record, TaskState.ABANDONED, f"SLA timeout ({record.task.sla_seconds}s)")
+            # Release busy state — robot is no longer executing this task.
+            self._clear_busy(winning_bid.robot_id)
 
             # No reservation to refund — payment only on delivery
 
@@ -933,6 +990,12 @@ class AuctionEngine:
             TaskState.DELIVERED,
             f"payload received, SLA {sla_label} ({elapsed:.0f}s < {sla}s)",
         )
+
+        # Release busy state — the robot is done executing and can bid again.
+        # Previously _busy_until stayed set for the full duration_map window
+        # even when execute took a fraction of it (e.g. a 1.4s teleop kept the
+        # robot blocked for 30 minutes), gating the operator from the next task.
+        self._clear_busy(winning_bid.robot_id)
 
         return {
             "request_id": request_id,
@@ -1142,6 +1205,7 @@ class AuctionEngine:
 
             # BID_ACCEPTED -> PROVIDER_CANCELLED
             self._transition(record, TaskState.PROVIDER_CANCELLED, f"provider cancelled ({cancelled_robot_id})")
+            self._clear_busy(cancelled_robot_id)
 
             # No reservation to refund — payment only on delivery
 
@@ -1172,6 +1236,7 @@ class AuctionEngine:
 
         # IN_PROGRESS -> ABANDONED
         self._transition(record, TaskState.ABANDONED, f"manually abandoned ({abandoned_robot_id} unresponsive)")
+        self._clear_busy(abandoned_robot_id)
 
         # No reservation to refund — payment only on delivery
 

--- a/auction/mcp_robot_adapter.py
+++ b/auction/mcp_robot_adapter.py
@@ -219,7 +219,9 @@ class MCPRobotAdapter:
             if resp.status_code >= 400:
                 log.warning(
                     "MCP call %s to %s failed after retry: HTTP %d",
-                    method, self.robot_id, resp.status_code,
+                    method,
+                    self.robot_id,
+                    resp.status_code,
                 )
                 return None
 

--- a/auction/mcp_tools.py
+++ b/auction/mcp_tools.py
@@ -493,6 +493,29 @@ def register_auction_tools(
         except KeyError as exc:
             return _error_response(exc)
 
+    @mcp.tool()
+    async def auction_get_robot_status(robot_id: str) -> dict:
+        """Get the current fleet-level state of a single robot.
+
+        Returns busy state (including ``busy_remaining_seconds`` if still
+        executing), counts of tasks won / active / completed, and the
+        operator's advertised config (accepted_task_types, min_bid_cents,
+        service_radius_km, mcp_endpoint, location).
+
+        Useful for:
+        - Checking whether a robot is available before posting a similar task
+        - Debugging why a robot isn't bidding (busy, wrong category, out of range)
+        - Operator health dashboards / runbooks
+
+        The ``found`` field is False when ``robot_id`` isn't in the in-memory
+        fleet (typo, never registered, or not yet discovered from on-chain).
+        """
+        try:
+            result = engine.get_robot_status(robot_id)
+            return _decimals_to_strings(result)
+        except Exception as exc:
+            return _error_response(exc)
+
     # ------------------------------------------------------------------
     # v1.0 tools: wallet + operator management
     # ------------------------------------------------------------------

--- a/auction/tests/test_engine.py
+++ b/auction/tests/test_engine.py
@@ -767,3 +767,70 @@ class TestAutoAccept:
 
         # Timer should have auto-confirmed delivery -> SETTLED
         assert record.state == TaskState.SETTLED
+
+
+class TestBusyStateAndRobotStatus:
+    """PR: _busy_until cleared on DELIVERED + new get_robot_status engine method."""
+
+    @pytest.mark.asyncio
+    async def test_busy_cleared_on_deliver(self):
+        """Robot's busy state releases when execute completes (state = DELIVERED).
+
+        Previously the robot stayed "busy" for the full duration_map window (30 min
+        for most categories) even when execute took ~seconds. This blocked the
+        operator from bidding on the next task unnecessarily.
+        """
+        engine, _wallet, _rep = _build_engine_with_wallet()
+        post = engine.post_task(VALID_TASK_SPEC)
+        request_id = post["request_id"]
+        bids = engine.get_bids(request_id)
+        winner = bids["recommended_winner"]
+        engine.accept_bid(request_id, winner)
+
+        # Immediately after accept_bid, _busy_until should be set
+        robot = engine._robots_by_id[winner]
+        assert getattr(robot, "_busy_until", None) is not None
+
+        with _mock_httpx_patch():
+            await engine.execute(request_id)
+
+        # After execute → DELIVERED, busy state should be released
+        assert getattr(robot, "_busy_until", None) is None
+
+    def test_get_robot_status_unknown_id(self):
+        engine, _wallet, _rep = _build_engine_with_wallet()
+        result = engine.get_robot_status("does-not-exist")
+        assert result["found"] is False
+        assert result["robot_id"] == "does-not-exist"
+
+    @pytest.mark.asyncio
+    async def test_get_robot_status_reports_busy_then_released(self):
+        engine, _wallet, _rep = _build_engine_with_wallet()
+
+        # Before any task: not busy
+        robot_id = "fakerover-bay3"
+        pre = engine.get_robot_status(robot_id)
+        assert pre["found"] is True
+        assert pre["busy"] is False
+        assert pre["total_tasks_won"] == 0
+
+        post = engine.post_task(VALID_TASK_SPEC)
+        request_id = post["request_id"]
+        bids = engine.get_bids(request_id)
+        winner = bids["recommended_winner"]
+        engine.accept_bid(request_id, winner)
+
+        # After accept: winner reports busy with positive remaining seconds
+        mid = engine.get_robot_status(winner)
+        assert mid["busy"] is True
+        assert mid["busy_remaining_seconds"] > 0
+        assert mid["total_tasks_won"] == 1
+
+        with _mock_httpx_patch():
+            await engine.execute(request_id)
+
+        # After deliver: busy cleared, still counted as won
+        post_deliver = engine.get_robot_status(winner)
+        assert post_deliver["busy"] is False
+        assert post_deliver["busy_remaining_seconds"] == 0
+        assert post_deliver["total_tasks_won"] == 1

--- a/auction/tests/test_integration_v10.py
+++ b/auction/tests/test_integration_v10.py
@@ -509,6 +509,7 @@ class TestMCPToolsRegistered:
                 "auction_get_wallet_balance",
                 "auction_onboard_operator",
                 "auction_get_operator_status",
+                "auction_get_robot_status",
                 # Convenience tools (REC-16b, REC-19)
                 "auction_accept_and_execute",
                 "auction_quick_hire",


### PR DESCRIPTION
## Summary

Two related fixes surfaced during the NPC ROBOT end-to-end run.

### 1. Bug fix: `_busy_until` leaked until the duration_map timeout
When a task transitioned to DELIVERED, ABANDONED, or PROVIDER_CANCELLED, the winning robot's `_busy_until` kept the upper-bound window set by `accept_bid` (e.g. 30 min for `delivery_ground`, 2 h for `as_built`). A robot whose execute took 1 second stayed blocked for the full window.

**Observed on NPC ROBOT:** 1.4-second teleop execute left the robot showing `busy:1784s_remaining` to the next posted task.

**Fix:** added `_clear_busy(robot_id)` helper, called at the three relevant state transitions.

### 2. New tool: `auction_get_robot_status(robot_id)`
Returns a complete snapshot of a robot's fleet-level state:
```json
{
  \"robot_id\": \"...\", \"found\": true, \"busy\": bool, \"busy_until\": iso,
  \"busy_remaining_seconds\": int, \"total_tasks_won\": int,
  \"active_tasks\": int, \"completed_tasks\": int,
  \"accepted_task_types\": [...], \"min_bid_cents\": int,
  \"service_radius_km\": int, \"mcp_endpoint\": \"...\",
  \"location\": {\"latitude\": ..., \"longitude\": ...}
}
```
Previously you had to post a throwaway task and scan `filter_reasons` to infer busy state.

## Tests
- 3 new `TestBusyStateAndRobotStatus` cases: busy-cleared-on-deliver, unknown-robot-id returns `found: false`, busy reports-then-released
- Total 309 passed (was 306), all green
- `TestMCPToolsRegistered` expected list updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)