### PR TITLE
Capture NPC ROBOT rollout learnings: backlog + onboarding updates

### DIFF
--- a/docs/onboarding/ROBOT_ACTIVATION_SUMMARY.md
+++ b/docs/onboarding/ROBOT_ACTIVATION_SUMMARY.md
@@ -76,6 +76,24 @@ The `berlin_tumbller` plugin (ground teleop) is the simplest working example:
 - USDC settles to your wallet after QA passes.
 - Update pricing, sensors, or MCP URL any time with `auction_update_operator_profile`.
 
+## What will bite you (lessons from the first live_production rollout)
+
+These are not in the happy-path, but each one cost real time during the NPC ROBOT rollout. Save yourself the debugging.
+
+- **Don't set `MCP_BEARER_TOKEN` on your operator MCP server** unless you know the marketplace's `FLEET_MCP_TOKEN` value. The marketplace uses a single shared token to call every operator; if yours doesn't match, the server returns 401 and bids silently fail. Match Finland's posture: leave it unset.
+
+- **`sudo cloudflared service install` writes an incomplete plist on macOS.** The generated `/Library/LaunchDaemons/com.cloudflare.cloudflared.plist` references only the binary with no subcommand — cloudflared keeps crashing with `Use cloudflared tunnel run …` and launchd respawns it in a 5 s loop. Fix: manually write the plist with explicit `ProgramArguments` `[binary, "tunnel", "--config", "/etc/cloudflared/config.yml", "run", "<tunnel-name>"]`, and copy your config + credentials into `/etc/cloudflared/`. Reload with `launchctl unload` then `load`.
+
+- **Use a raw IP in the cloudflared `service:` line, not an mDNS `.local` hostname.** `http://berlin-tumbller-01.local:80` works but every request pays ~5 s for mDNS resolution — enough to trip the plugin's default 5 s `httpx` timeout. Raw IP drops latency to ~200 ms. If your router changes IPs, update the config.
+
+- **Marketplace restarts invalidate MCP sessions.** The `MCPRobotAdapter` in the marketplace caches the session id on the adapter instance and (pre-PR #33) never reset it. After any operator-side restart (OOM, redeploy), the next bid call sent a stale session id → server 404 → silent None bid. Fixed in PR #33 — if you see inexplicable `bid_count: 0` after a restart, make sure the marketplace's deploy includes that commit.
+
+- **Unknown `equipment_type` is rejected, not silently normalized.** Post PR #28, `auction_onboard_operator_guided` returns `UNKNOWN_EQUIPMENT_TYPE` if your type isn't in `SENSOR_TO_CATEGORY` / `COMMON_MODELS`. See "Pick an equipment type" above — ask the admin to add your type first.
+
+- **Busy state used to over-hold the robot.** A 1 s execute left the robot "busy" for the full `duration_map` window (30 min for most categories). Fixed in PR #34 — `_busy_until` is now released when the task enters `DELIVERED` / `ABANDONED` / `PROVIDER_CANCELLED`.
+
+- **Real USDC settlement from the MCP is not wired yet (as of 2026-04-22).** An agent calling `auction_post_task` → `auction_confirm_delivery` triggers the in-memory demo ledger and (if configured) a Stripe Connect transfer. The `payment_method: "usdc"` field on Task is accepted but the settlement path doesn't branch on it. If you need real USDC-on-Base from a specific buyer wallet, that's [IMP-109](../research/IMPROVEMENT_BACKLOG.yaml) in the v1.5 roadmap. The `yakrobot.bid/demo/` web UI has a USDC path via a separate flow; the MCP surface does not.
+
 ## Help
 
 - Full onboarding reference: `[ROBOT_OPERATOR_ONBOARDING.md](./ROBOT_OPERATOR_ONBOARDING.md)`

--- a/docs/onboarding/ROBOT_OPERATOR_ONBOARDING.md
+++ b/docs/onboarding/ROBOT_OPERATOR_ONBOARDING.md
@@ -96,6 +96,9 @@ If you provide just your company name, equipment type, and location, the platfor
 - Without a USDC wallet, payments are **held by the platform** until you provide a destination
 - Without a Stripe Connect account, card/bank payments are unavailable — USDC only
 - You can add both at any time after registration
+- **What settles today, via which channel:**
+  - **Via the marketplace web UI (`yakrobot.bid/demo`)**: Card / Bank / USDC all wired. Real money moves.
+  - **Via the marketplace MCP tools (`auction_post_task` → `auction_confirm_delivery`)**: Internal ledger always; Stripe Connect transfer to your `acct_{robot_id}` if the platform has `STRIPE_SECRET_KEY` and you registered with a `stripe_connect_id`. **USDC-on-Base from a buyer's own wallet is not wired through MCP yet** (tracked as IMP-109 in `docs/research/IMPROVEMENT_BACKLOG.yaml` for v1.5). The `payment_method: "usdc"` field on a task spec is accepted and validated but the settlement code does not branch on it.
 
 **Test vs. production registration:**
 - If you register without a working MCP endpoint (i.e. no real hardware connected), your robot is flagged as `is_test = true` on-chain
@@ -129,6 +132,8 @@ If you have a robot MCP server running, provide the URL during registration or u
 Use the [8004 robot framework](https://github.com/YakRoboticsGarage/yakrover-8004-mcp): create a plugin package at `src/robots/<your_robot>/` with three files — `__init__.py` (subclass `RobotPlugin`, implement `bid()` and `execute()`), `client.py` (how you talk to your hardware — HTTP, SDK, serial, ROS, whatever), and `tools.py` (any robot-specific MCP tools). The framework **automatically** wires up `robot_submit_bid`, `robot_execute_task`, and `robot_get_pricing` for you — no need to implement them directly.
 
 **Host it somewhere public.** Fly.io (~$5/month for a single-robot deployment) or ngrok for testing. You need a stable HTTPS URL — that's what you paste into `mcp_endpoint_url` at registration.
+
+> **Do not set `MCP_BEARER_TOKEN` on your MCP server** unless you are coordinating with the platform operator. The marketplace uses a single shared `FLEET_MCP_TOKEN` when calling every operator; if your server enforces a different bearer, the marketplace's calls return 401 and your bids silently never reach the auction. Leave auth unset for v1 (matches Finland) — see `ROBOT_ACTIVATION_SUMMARY.md` "What will bite you" for context. Firmware-level auth for a public-internet-exposed teleop surface is tracked as IMP-110.
 
 **Partial-hardware readiness.** If your robot has, say, a LiDAR working but the thermal camera isn't wired yet, use a simple `availability.json` file that your plugin's `bid()` method reads on each call. Advertise all your intended capabilities at registration, flip the offline ones to `{"available": false}` in the JSON, and your `bid()` returns `None` (declining) for tasks that need them. Flip them back on once the hardware lands — no redeploy needed. The `berlin_tumbller` plugin is a worked reference for this pattern.
 

--- a/docs/research/IMPROVEMENT_BACKLOG.yaml
+++ b/docs/research/IMPROVEMENT_BACKLOG.yaml
@@ -1,13 +1,13 @@
 meta:
   created: '2026-04-01'
-  last_updated: '2026-04-21'
-  total_items: 102
+  last_updated: '2026-04-22'
+  total_items: 115
   implemented: 44
   deferred: 18
   rejected: 1
-  proposed: 39
-  source: Automated daily research agent + weekly synthesis + 100-robot fleet sprint
-  last_sync: "2026-04-21 — R-042 (ACH fraud patterns). Added IMP-099 (hold operator ACH transfer until delivery), IMP-100 (first-payment ACH cap $2,500), IMP-101 (Nacha Phase 2 compliance policy — CRITICAL, due June 22 2026), IMP-102 (balance sufficiency check). 44 implemented, 39 proposed, 18 deferred, 1 rejected."
+  proposed: 52
+  source: Automated daily research agent + weekly synthesis + 100-robot fleet sprint + NPC ROBOT live-production rollout
+  last_sync: "2026-04-22 — NPC ROBOT E2E rollout findings. Added IMP-109 (wire USDC settlement through MCP — HIGH, production payment rail gap: payment_method on Task accepts 'usdc' but confirm_delivery hardcodes 'buyer' ledger debit and never dispatches on method), IMP-110 (firmware-level auth on public-exposed /motor/* — HIGH, Anuraj review pending for option A/B/C), IMP-111 (ERC-8004 token ownership transfer to operator), IMP-112 (automated IPFS metadata re-upload when operator profile changes), IMP-113 (expose plugin-side availability.json in auction_get_robot_status), IMP-114 (restore completed task counts from SyncTaskStore on marketplace restart), IMP-115 (MQTT reverse-connection architecture for operator→robot path). 44 implemented, 52 proposed, 18 deferred, 1 rejected."
 proposals:
 - id: IMP-001
   title: Integrate external PLS license verification API (Checkr or MeshVerify)
@@ -1965,3 +1965,160 @@ proposals:
   proposed_date: '2026-04-22'
   decision_date: null
   decision_notes: null
+
+- id: IMP-109
+  title: "Wire USDC-on-Base settlement through the marketplace MCP (production payments)"
+  description: >
+    Today any agent can call auction_post_task/get_bids/accept_and_execute/confirm_delivery
+    via the marketplace MCP and run a full auction, but the only real-money settlement path
+    wired is Stripe Connect (engine.py:1099). The payment_method field on Task accepts
+    "usdc" and the buyer wallet_id is hardcoded to the literal string "buyer" at
+    engine.py:1061 — there is no branch in confirm_delivery that dispatches on
+    payment_method, and no way through the MCP surface to specify which on-chain wallet
+    pays. Concrete subscope: (a) add buyer_wallet_address to the Task dataclass and pass
+    through auction_post_task; (b) switch on task.payment_method in
+    engine.confirm_delivery with a new USDC settlement adapter; (c) implement EIP-3009
+    transferWithAuthorization gasless flow — buyer signs an authorization off-chain,
+    marketplace relays on-chain and pays gas (critical because real buyer wallets often
+    have USDC but 0 ETH, e.g. BUYER_WALLET 0xb84165… during NPC ROBOT dogfooding had
+    12.77 USDC and 0 ETH); (d) expose either "pre-signed authorization in task_spec"
+    (protocol-pure) or "marketplace signs as BUYER_WALLET env holder" (dogfooding shortcut).
+    Without this, the marketplace's MCP is not actually a production payment rail —
+    only the yakrobot.bid/demo web form touches real USDC today.
+  module: auction/settlement
+  research_source: NPC ROBOT E2E rollout (2026-04-22)
+  evidence: docs/DECISIONS.md (FD-1 settlement abstraction); tumbller-esp32s3/docs/MARKETPLACE_REGISTRATION_PLAN.md step 9 notes
+  effort: large
+  priority: high
+  status: proposed
+  proposed_date: '2026-04-22'
+  decision_date: null
+  decision_notes: Fits squarely in v1.5 FD-1. During NPC ROBOT E2E run, confirmed the gap — task settles in demo ledger only, no USDC moved from buyer 0xb84165… to operator 0x6af6….
+
+- id: IMP-110
+  title: "Firmware-level auth on public-exposed robot /motor/* endpoints"
+  description: >
+    NPC ROBOT ships v1 with no auth on the Tumbller's HTTP endpoints, matching Finland's
+    model. Finland is safe because its hostname is .local (LAN-only); NPC ROBOT is exposed
+    publicly via Cloudflare Tunnel at berlin-tumbller-01.yakrover.online, so anyone who
+    discovers the URL can issue /motor/forward etc. with zero cost to them. For real-money
+    teleop on Base mainnet this is a real risk — the marketplace paywall is upstream of the
+    attack vector. Options (per discussion with Anuraj, see
+    tumbller-esp32s3/docs/MARKETPLACE_REGISTRATION_PLAN.md deferred section):
+    (A) bake Authorization: Bearer check into firmware — rotate by reflash for v1, NVS-stored
+    for fleet ≥2; (B) Cloudflare Access policy scoped to the operator's Fly MCP egress —
+    no firmware change, auth at the edge; (C) network-layer isolation via WARP Connector
+    restricting the tunnel to the Fly app's IP. Decision factors: token rotation frequency,
+    defense-in-depth preference, Cloudflare Access cost.
+  module: firmware/operator-security
+  research_source: NPC ROBOT E2E rollout (2026-04-22)
+  evidence: tumbller-esp32s3/docs/MARKETPLACE_REGISTRATION_PLAN.md § "Pending review with Anuraj"
+  effort: medium
+  priority: high
+  status: proposed
+  proposed_date: '2026-04-22'
+  decision_date: null
+  decision_notes: Blocking for responsible teleop pricing growth. Accepted risk at v1 because of low throughput + physical safety (robot on its back during tests). Revisit as soon as Anuraj weighs in on option A vs B vs C.
+
+- id: IMP-111
+  title: "Transfer ERC-8004 token ownership from platform wallet to operator wallet post-registration"
+  description: >
+    During auction_onboard_operator_guided (platform-signs mode), the ERC-8004 token is
+    minted with the platform as owner. The onboarding doc already mentions ownership
+    "can be transferred to your wallet later" but there is no MCP tool that does it.
+    For true sovereignty and live_production credibility, operators should hold their own
+    token. Add auction_transfer_robot_ownership(robot_id, new_owner_address) backed by
+    agent0-sdk's transfer flow on the ERC-8004 registry.
+  module: auction/registration
+  research_source: NPC ROBOT E2E rollout (2026-04-22)
+  evidence: docs/onboarding/ROBOT_OPERATOR_ONBOARDING.md "Minimal Registration" section
+  effort: small
+  priority: medium
+  status: proposed
+  proposed_date: '2026-04-22'
+  decision_date: null
+  decision_notes: null
+
+- id: IMP-112
+  title: "Automate IPFS metadata re-upload when operator profile changes"
+  description: >
+    auction_update_operator_profile currently only updates in-memory fleet state — the
+    tool's own docstring flags this: "On-chain metadata updates (location, pricing, wallet)
+    require a separate IPFS re-upload which is not yet automated — note this to the operator
+    and log the change for manual sync." Means the IPFS agent card drifts out of sync with
+    the truth. Implement: on relevant field changes (location, sensors, mcp_endpoint,
+    min_bid_cents, service_radius_km, wallet addresses), build a new agent card, pin to
+    Pinata, call setAgentURI on the ERC-8004 registry.
+  module: auction/registration
+  research_source: NPC ROBOT E2E rollout (2026-04-22)
+  evidence: auction/mcp_tools.py auction_update_operator_profile docstring
+  effort: medium
+  priority: medium
+  status: proposed
+  proposed_date: '2026-04-22'
+  decision_date: null
+  decision_notes: null
+
+- id: IMP-113
+  title: "Expose plugin-side availability map in auction_get_robot_status"
+  description: >
+    auction_get_robot_status (shipped in PR #34) returns fleet-level busy state, task
+    counts, advertised config. But it says nothing about the operator's plugin-side
+    availability.json (e.g. movement online, thermal offline with reason "SHT30 not wired").
+    That live capability picture is what matters for "is this robot actually usable right
+    now" vs just "has it been busy recently". Extend the tool to fan out a
+    robot_get_pricing call to the operator's MCP endpoint and include the availability
+    payload (or a structured "unreachable" response). Bound by a short timeout so a dead
+    operator doesn't slow the caller.
+  module: auction/mcp_tools
+  research_source: NPC ROBOT E2E rollout (2026-04-22)
+  evidence: PR #34 (feat: busy-clear-and-robot-status)
+  effort: small
+  priority: low
+  status: proposed
+  proposed_date: '2026-04-22'
+  decision_date: null
+  decision_notes: null
+
+- id: IMP-114
+  title: "Restore completed task counts from SyncTaskStore on marketplace restart"
+  description: >
+    Observed during NPC ROBOT E2E after PR #34 deploy: auction_get_robot_status reported
+    total_tasks_won: 1, active_tasks: 1, completed_tasks: 0 — even though the prior task
+    had reached state "settled". _load_from_store in engine.py restores *active* tasks
+    but not the settled history, so total-tasks / completed-tasks counters look wrong after
+    any redeploy. Operator reputation/volume signals are less trustworthy as a result.
+    Fix: extend _load_from_store to also re-hydrate terminal-state (SETTLED) tasks so the
+    counts reflect real lifetime activity.
+  module: auction/engine
+  research_source: NPC ROBOT E2E rollout (2026-04-22)
+  evidence: auction/engine.py _load_from_store; auction_get_robot_status output after 2026-04-22 12:14 deploy
+  effort: small
+  priority: low
+  status: proposed
+  proposed_date: '2026-04-22'
+  decision_date: null
+  decision_notes: null
+
+- id: IMP-115
+  title: "Reverse-connection (MQTT) architecture for operator→robot path"
+  description: >
+    The default "operator Fly MCP → Cloudflare Tunnel → always-on cloudflared on home
+    machine → LAN HTTP → robot" chain requires something running at home 24/7. For
+    NPC ROBOT this is a launchd cloudflared daemon; it works but ties the robot to a
+    single physical location and a single always-on machine. Alternative: the ESP32 dials
+    out to an MQTT broker over TLS and subscribes to robots/{id}/commands; operator MCP
+    publishes commands. No inbound port, no tunnel, robot is portable to any WiFi with
+    outbound internet. Also eliminates the auth-at-the-edge problem (broker authenticates
+    the robot) — partially resolves IMP-110. Costs: firmware refactor (~1 day), broker
+    choice (HiveMQ Cloud free tier for 1 robot, or self-hosted Mosquitto on Fly ~$5/mo),
+    MCP-side pub/sub bridge.
+  module: operator-architecture
+  research_source: NPC ROBOT E2E rollout (2026-04-22)
+  evidence: tumbller-esp32s3/docs/MARKETPLACE_REGISTRATION_PLAN.md § "Other deferred items"
+  effort: medium
+  priority: low
+  status: proposed
+  proposed_date: '2026-04-22'
+  decision_date: null
+  decision_notes: Revisit when adding a second physical robot or when Anuraj's security review (IMP-110) makes this attractive as a defensive posture.


### PR DESCRIPTION
## Summary

Docs-only PR distilling lessons from the live NPC ROBOT rollout into the improvement backlog and the two onboarding docs. No code change, no deploy (demo/** and docs/** are outside the Fly paths filter).

## Backlog — 7 new items

| ID | Title | Priority |
|---|---|---|
| IMP-109 | Wire USDC-on-Base settlement through marketplace MCP (production payments) | HIGH |
| IMP-110 | Firmware-level auth on public-exposed robot `/motor/*` endpoints | HIGH |
| IMP-111 | Transfer ERC-8004 token ownership from platform wallet to operator wallet post-registration | medium |
| IMP-112 | Automate IPFS metadata re-upload when operator profile changes | medium |
| IMP-113 | Expose plugin-side availability map in `auction_get_robot_status` | low |
| IMP-114 | Restore completed task counts from `SyncTaskStore` on marketplace restart | low |
| IMP-115 | Reverse-connection (MQTT) architecture for operator→robot path | low |

**IMP-109 is the big one.** During E2E I confirmed `payment_method: "usdc"` is accepted on a Task but never branched on in `confirm_delivery` — `engine.py:1061` hardcodes `wallet.debit(\"buyer\", ...)`, always the in-memory ledger wallet_id. For real agent hiring via MCP with gasless Base USDC the scope is: add buyer_wallet_address to Task, dispatch on payment_method in settlement, implement EIP-3009 `transferWithAuthorization`. Fits v1.5's FD-1 settlement abstraction.

**IMP-110 is the security partner.** NPC ROBOT ships with zero auth on `/motor/*` — anyone who discovers the Cloudflare URL can move the wheels. Matches Finland's posture but Finland is LAN-only. Three options documented for Anuraj's review (firmware bearer, Cloudflare Access, WARP Connector).

Meta counts refreshed: 115 items total, 52 proposed, 44 implemented.

## Docs — surgical additions

**`ROBOT_ACTIVATION_SUMMARY.md`** — new "What will bite you" section at the bottom with six concrete gotchas:
- `MCP_BEARER_TOKEN` vs `FLEET_MCP_TOKEN` mismatch silently fails bids
- `sudo cloudflared service install` writes an incomplete plist
- mDNS `.local` in tunnel service line adds ~5s per request
- `MCPRobotAdapter` session staleness post-restart (fixed by PR #33)
- `UNKNOWN_EQUIPMENT_TYPE` rejection (PR #28) — ask admin to add first
- Busy-state over-hold (fixed by PR #34)
- Real-USDC-via-MCP gap → IMP-109

**`ROBOT_OPERATOR_ONBOARDING.md`**:
- Wallet section now explicitly lists what settles through which channel today (web UI = all three methods, MCP = ledger + optional Stripe, no USDC via MCP)
- "Host it somewhere public" gains a warning about `MCP_BEARER_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)